### PR TITLE
repo: improve handling for missing schema elements and add defaults

### DIFF
--- a/tests/unit/test_bot_tokens_repo_schema_compat.py
+++ b/tests/unit/test_bot_tokens_repo_schema_compat.py
@@ -1,0 +1,74 @@
+import pytest
+
+import repositories.bot_tokens_repo as bot_tokens_repo_module
+from repositories.bot_tokens_repo import BotTokensRepository
+
+
+class _FakeSession:
+    pass
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.unit
+def test_list_bot_tokens_returns_empty_when_table_missing(monkeypatch):
+    fake_session = _FakeSession()
+    monkeypatch.setattr(
+        bot_tokens_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        bot_tokens_repo_module,
+        "check_table_exists",
+        lambda session, table_name: False,
+    )
+
+    repo = BotTokensRepository()
+    assert repo.list_bot_tokens(is_active=True) == []
+
+
+@pytest.mark.unit
+def test_get_bot_token_returns_none_when_table_missing(monkeypatch):
+    fake_session = _FakeSession()
+    monkeypatch.setattr(
+        bot_tokens_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        bot_tokens_repo_module,
+        "check_table_exists",
+        lambda session, table_name: False,
+    )
+
+    repo = BotTokensRepository()
+    assert repo.get_bot_token("any-token-id") is None
+
+
+@pytest.mark.unit
+def test_create_bot_token_raises_clear_error_when_table_missing(monkeypatch):
+    fake_session = _FakeSession()
+    monkeypatch.setattr(
+        bot_tokens_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        bot_tokens_repo_module,
+        "check_table_exists",
+        lambda session, table_name: False,
+    )
+
+    repo = BotTokensRepository()
+    with pytest.raises(RuntimeError, match="missing table 'bot_tokens'"):
+        repo.create_bot_token("123:abc")

--- a/tests/unit/test_broadcasts_repo_schema_compat.py
+++ b/tests/unit/test_broadcasts_repo_schema_compat.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timezone
+
+import pytest
+
+import repositories.broadcasts_repo as broadcasts_repo_module
+from repositories.broadcasts_repo import BroadcastsRepository
+
+
+class _FakeResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def mappings(self):
+        return self
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return []
+
+
+class _FakeSession:
+    def __init__(self, row=None):
+        self.calls = []
+        self._row = row
+
+    def execute(self, statement, params=None):
+        sql = statement.text if hasattr(statement, "text") else str(statement)
+        self.calls.append((sql, params or {}))
+
+        if "FROM broadcasts" in sql and "WHERE broadcast_id = :broadcast_id" in sql:
+            return _FakeResult(self._row)
+
+        return _FakeResult()
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.unit
+def test_create_broadcast_omits_bot_token_id_when_column_missing(monkeypatch):
+    fake_session = _FakeSession()
+    monkeypatch.setattr(
+        broadcasts_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        broadcasts_repo_module,
+        "get_table_columns",
+        lambda session, table_name: [
+            "broadcast_id",
+            "admin_id",
+            "message",
+            "target_user_ids",
+            "scheduled_time_utc",
+            "status",
+            "created_at_utc",
+            "updated_at_utc",
+        ],
+    )
+    monkeypatch.setattr(broadcasts_repo_module.uuid, "uuid4", lambda: "fixed-broadcast-id")
+
+    repo = BroadcastsRepository()
+    broadcast_id = repo.create_broadcast(
+        admin_id=123,
+        message="hello",
+        target_user_ids=[123],
+        scheduled_time_utc=datetime(2026, 2, 19, 23, 0, tzinfo=timezone.utc),
+        bot_token_id="token-id",
+    )
+
+    assert broadcast_id == "fixed-broadcast-id"
+    assert len(fake_session.calls) == 1
+    insert_sql, insert_params = fake_session.calls[0]
+    assert "INSERT INTO broadcasts" in insert_sql
+    assert "bot_token_id" not in insert_sql
+    assert "bot_token_id" not in insert_params
+
+
+@pytest.mark.unit
+def test_get_broadcast_selects_null_bot_token_id_when_column_missing(monkeypatch):
+    fake_row = {
+        "broadcast_id": "b1",
+        "admin_id": "123",
+        "message": "hello",
+        "target_user_ids": "[123]",
+        "scheduled_time_utc": "2026-02-19T23:00:00Z",
+        "status": "pending",
+        "bot_token_id": None,
+        "created_at_utc": "2026-02-19T23:00:00Z",
+        "updated_at_utc": "2026-02-19T23:00:00Z",
+    }
+    fake_session = _FakeSession(row=fake_row)
+    monkeypatch.setattr(
+        broadcasts_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        broadcasts_repo_module,
+        "get_table_columns",
+        lambda session, table_name: [
+            "broadcast_id",
+            "admin_id",
+            "message",
+            "target_user_ids",
+            "scheduled_time_utc",
+            "status",
+            "created_at_utc",
+            "updated_at_utc",
+        ],
+    )
+
+    repo = BroadcastsRepository()
+    broadcast = repo.get_broadcast("b1")
+
+    assert broadcast is not None
+    assert broadcast.bot_token_id is None
+    assert len(fake_session.calls) == 1
+    select_sql, _ = fake_session.calls[0]
+    assert "NULL AS bot_token_id" in select_sql

--- a/tests/unit/test_instances_repo_schema_compat.py
+++ b/tests/unit/test_instances_repo_schema_compat.py
@@ -1,0 +1,88 @@
+"""Tests that InstancesRepository adapts to both legacy and simplified template schemas.
+
+Migration 004 dropped template_kind and target_direction from promise_templates.
+The _template_join_fields() helper must return literal defaults when those columns
+are absent so that SQL queries and downstream consumers continue to work.
+"""
+import pytest
+
+import repositories.instances_repo as instances_repo_module
+from repositories.instances_repo import InstancesRepository
+
+
+class _FakeResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return []
+
+
+class _FakeSession:
+    """Records SQL calls and stubs information_schema lookups."""
+
+    def __init__(self, *, has_template_kind: bool):
+        self.calls: list = []
+        self._has_template_kind = has_template_kind
+
+    def execute(self, statement, params=None):
+        sql = statement.text if hasattr(statement, "text") else str(statement)
+        self.calls.append((sql, params or {}))
+
+        if "information_schema.columns" in sql:
+            if self._has_template_kind and "template_kind" in sql:
+                return _FakeResult(row=("template_kind",))
+            return _FakeResult(row=None)
+
+        return _FakeResult()
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.unit
+def test_template_join_fields_returns_real_columns_on_legacy_schema():
+    session = _FakeSession(has_template_kind=True)
+    fields = InstancesRepository._template_join_fields(session)
+    assert "t.template_kind" in fields
+    assert "t.target_direction" in fields
+    assert "'commitment'" not in fields
+
+
+@pytest.mark.unit
+def test_template_join_fields_returns_defaults_on_simplified_schema():
+    session = _FakeSession(has_template_kind=False)
+    fields = InstancesRepository._template_join_fields(session)
+    assert "'commitment' as template_kind" in fields
+    assert "'at_least' as target_direction" in fields
+    assert "t.template_kind" not in fields
+
+
+@pytest.mark.unit
+def test_list_active_instances_uses_defaults_on_simplified_schema(monkeypatch):
+    """Verifies the generated SQL uses literal defaults, not dropped column names."""
+    fake_session = _FakeSession(has_template_kind=False)
+    monkeypatch.setattr(
+        instances_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+
+    repo = InstancesRepository()
+    repo.list_active_instances(user_id=999)
+
+    sql_calls = [sql for sql, _ in fake_session.calls if "promise_instances" in sql]
+    assert len(sql_calls) == 1
+    assert "'commitment' as template_kind" in sql_calls[0]
+    assert "'at_least' as target_direction" in sql_calls[0]

--- a/tests/unit/test_planner_api_adapter_templates_schema_compat.py
+++ b/tests/unit/test_planner_api_adapter_templates_schema_compat.py
@@ -1,0 +1,128 @@
+"""Tests that PlannerAPIAdapter.list_templates / get_template do not crash
+when templates lack legacy fields (level, why, done, effort, target_direction).
+
+Migration 004 removed these columns.  The adapter must use .get() with defaults.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+
+def _make_adapter():
+    """Construct a PlannerAPIAdapter with mocked dependencies, bypassing __init__."""
+    from services.planner_api_adapter import PlannerAPIAdapter
+
+    adapter = object.__new__(PlannerAPIAdapter)
+    adapter.templates_repo = MagicMock()
+    adapter.unlocks_service = MagicMock()
+    adapter.promises_repo = MagicMock()
+    adapter.actions_repo = MagicMock()
+    adapter.instances_repo = MagicMock()
+    adapter.settings_repo = MagicMock()
+    adapter.sessions_repo = MagicMock()
+    adapter.distractions_repo = MagicMock()
+    adapter.profile_repo = MagicMock()
+    adapter.follows_repo = MagicMock()
+    adapter.reports_service = MagicMock()
+    adapter.ranking_service = MagicMock()
+    adapter.reminders_service = MagicMock()
+    adapter.sessions_service = MagicMock()
+    adapter.content_service = MagicMock()
+    adapter.time_estimation_service = MagicMock()
+    adapter.content_management_service = MagicMock()
+    adapter.settings_service = MagicMock()
+    adapter.profile_service = MagicMock()
+    adapter.social_service = MagicMock()
+    adapter.schema_service = MagicMock()
+    adapter.query_service = MagicMock()
+    adapter.nightly_state_repo = MagicMock()
+    return adapter
+
+
+SIMPLIFIED_TEMPLATE = {
+    "template_id": "t-1",
+    "title": "Learn Chinese",
+    "description": "Practice Mandarin",
+    "category": "language",
+    "target_value": 3.0,
+    "metric_type": "hours",
+    "emoji": None,
+    "is_active": True,
+    "created_at_utc": "2026-01-01",
+    "updated_at_utc": "2026-01-01",
+}
+
+
+@pytest.mark.unit
+def test_list_templates_no_keyerror_on_simplified_schema():
+    adapter = _make_adapter()
+    adapter.templates_repo.list_templates.return_value = [dict(SIMPLIFIED_TEMPLATE)]
+    adapter.unlocks_service.annotate_templates_with_unlock_status.return_value = [
+        {**SIMPLIFIED_TEMPLATE, "unlocked": True, "lock_reason": None}
+    ]
+
+    result = adapter.list_templates(user_id=1, category="language")
+    assert "Error listing templates" not in result
+    assert "Learn Chinese" in result
+    assert "3.0h" in result
+
+
+@pytest.mark.unit
+def test_list_templates_no_keyerror_when_template_has_level():
+    """Legacy templates that still have level should include it in parentheses."""
+    adapter = _make_adapter()
+    t = {**SIMPLIFIED_TEMPLATE, "level": "beginner"}
+    adapter.templates_repo.list_templates.return_value = [t]
+    adapter.unlocks_service.annotate_templates_with_unlock_status.return_value = [
+        {**t, "unlocked": True, "lock_reason": None}
+    ]
+
+    result = adapter.list_templates(user_id=1)
+    assert "(beginner)" in result
+
+
+@pytest.mark.unit
+def test_get_template_no_keyerror_on_simplified_schema():
+    adapter = _make_adapter()
+    adapter.templates_repo.get_template.return_value = dict(SIMPLIFIED_TEMPLATE)
+    adapter.templates_repo.get_prerequisites.return_value = []
+    adapter.unlocks_service.get_unlock_status.return_value = {
+        "unlocked": True, "lock_reason": None
+    }
+
+    result = adapter.get_template(user_id=1, template_id="t-1")
+    assert "Error getting template" not in result
+    assert "Learn Chinese" in result
+    assert "Description: Practice Mandarin" in result
+    assert "Level:" not in result
+    assert "Done means:" not in result
+    assert "Effort:" not in result
+
+
+@pytest.mark.unit
+def test_get_template_includes_target_direction_default():
+    adapter = _make_adapter()
+    adapter.templates_repo.get_template.return_value = dict(SIMPLIFIED_TEMPLATE)
+    adapter.templates_repo.get_prerequisites.return_value = []
+    adapter.unlocks_service.get_unlock_status.return_value = {
+        "unlocked": True, "lock_reason": None
+    }
+
+    result = adapter.get_template(user_id=1, template_id="t-1")
+    assert "(at_least)" in result
+
+
+@pytest.mark.unit
+def test_get_template_falls_back_to_why_for_description():
+    """Legacy templates have 'why' instead of 'description'."""
+    adapter = _make_adapter()
+    t = dict(SIMPLIFIED_TEMPLATE)
+    del t["description"]
+    t["why"] = "Because learning is fun"
+    adapter.templates_repo.get_template.return_value = t
+    adapter.templates_repo.get_prerequisites.return_value = []
+    adapter.unlocks_service.get_unlock_status.return_value = {
+        "unlocked": True, "lock_reason": None
+    }
+
+    result = adapter.get_template(user_id=1, template_id="t-1")
+    assert "Description: Because learning is fun" in result

--- a/tests/unit/test_promises_template_creation_schema_compat.py
+++ b/tests/unit/test_promises_template_creation_schema_compat.py
@@ -1,0 +1,137 @@
+"""Tests that the promise visibility endpoint handles template creation
+correctly on both legacy schema (has canonical_key) and simplified schema
+(canonical_key dropped by migration 004).
+"""
+import pytest
+
+import repositories.templates_repo as templates_repo_module
+from repositories.templates_repo import TemplatesRepository
+
+
+class _FakeResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return []
+
+
+class _FakeSession:
+    def __init__(self, *, has_canonical_key: bool, has_description: bool):
+        self.calls: list = []
+        self._has_canonical_key = has_canonical_key
+        self._has_description = has_description
+
+    def execute(self, statement, params=None):
+        sql = statement.text if hasattr(statement, "text") else str(statement)
+        self.calls.append((sql, params or {}))
+
+        if "information_schema.columns" in sql:
+            col = (params or {}).get("column_name", "")
+            if not col:
+                if "'description'" in sql or "= 'description'" in sql or "column_name = 'description'" in sql:
+                    col = "description"
+                elif "'canonical_key'" in sql or "column_name = 'canonical_key'" in sql:
+                    col = "canonical_key"
+
+            if col == "canonical_key" and self._has_canonical_key:
+                return _FakeResult(row=(col,))
+            if col == "description" and self._has_description:
+                return _FakeResult(row=(col,))
+            if col == "created_by_user_id":
+                return _FakeResult(row=(col,))
+            return _FakeResult(row=None)
+
+        return _FakeResult()
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.unit
+def test_has_column_detects_canonical_key_presence():
+    session = _FakeSession(has_canonical_key=True, has_description=True)
+    repo = TemplatesRepository()
+    assert repo._has_column(session, "promise_templates", "canonical_key") is True
+
+
+@pytest.mark.unit
+def test_has_column_detects_canonical_key_absence():
+    session = _FakeSession(has_canonical_key=False, has_description=True)
+    repo = TemplatesRepository()
+    assert repo._has_column(session, "promise_templates", "canonical_key") is False
+
+
+@pytest.mark.unit
+def test_create_template_simplified_schema_uses_description_key(monkeypatch):
+    """On simplified schema, create_template should write description, not why."""
+    fake_session = _FakeSession(has_canonical_key=False, has_description=True)
+    monkeypatch.setattr(
+        templates_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+
+    repo = TemplatesRepository()
+    template_data = {
+        "title": "Learn Chinese",
+        "description": "Track progress on learning Chinese",
+        "category": "language",
+        "target_value": 3.0,
+        "metric_type": "hours",
+        "is_active": True,
+        "created_by_user_id": "123",
+    }
+    repo.create_template(template_data)
+
+    insert_calls = [
+        (sql, p) for sql, p in fake_session.calls if "INSERT INTO promise_templates" in sql
+    ]
+    assert len(insert_calls) == 1
+    sql, params = insert_calls[0]
+    assert "description" in sql
+    assert params["description"] == "Track progress on learning Chinese"
+    assert "canonical_key" not in sql
+    assert "level" not in sql
+
+
+@pytest.mark.unit
+def test_create_template_legacy_schema_maps_description_to_why(monkeypatch):
+    """On legacy schema (no 'description' column), create_template should map
+    the 'description' input to the 'why' column."""
+    fake_session = _FakeSession(has_canonical_key=True, has_description=False)
+    monkeypatch.setattr(
+        templates_repo_module,
+        "get_db_session",
+        lambda: _FakeSessionContext(fake_session),
+    )
+
+    repo = TemplatesRepository()
+    template_data = {
+        "title": "Learn Chinese",
+        "description": "Track progress on learning Chinese",
+        "category": "language",
+        "target_value": 3.0,
+        "metric_type": "hours",
+        "is_active": True,
+    }
+    repo.create_template(template_data)
+
+    insert_calls = [
+        (sql, p) for sql, p in fake_session.calls if "INSERT INTO promise_templates" in sql
+    ]
+    assert len(insert_calls) == 1
+    sql, params = insert_calls[0]
+    assert "why" in sql
+    assert params.get("why") == "Track progress on learning Chinese"

--- a/tm_bot/llms/llm_handler.py
+++ b/tm_bot/llms/llm_handler.py
@@ -337,7 +337,7 @@ class LLMHandler:
             "- 'browse templates' / 'show me templates' → open_mini_app('/templates', 'templates')\n"
             "- 'my promises' / 'show tasks' → get_promises()\n"
             "- 'I want to go to gym 2 times this week' → list_templates(category='fitness'), find matching template, check unlock status, subscribe_template()\n"
-            "- 'I want to learn French for 3 hours this week' → list_templates(category='language'), find matching template, subscribe_template()\n"
+            "- 'I want to learn French/Chinese for 3 hours this week' → list_templates(category='language'); if a matching template exists, subscribe_template(); otherwise create_promise with title and hours_per_week (e.g. 3). Do not ask for level.\n"
             "- 'I want to limit social media to 2 hours this week' → list_templates(category='digital_wellness'), find budget template, subscribe_template()\n"
             "- 'create a promise to finish project by end of March' → resolve_datetime('end of March'), then create_promise with target_date\n"
             "- User fails a week → suggest downgrading to lower-level templates (e.g., L2 → L1) using list_templates() and subscribe_template()\n"

--- a/tm_bot/repositories/reviews_repo.py
+++ b/tm_bot/repositories/reviews_repo.py
@@ -62,9 +62,9 @@ class ReviewsRepository:
                 return dict(existing._mapping)
 
         # Compute achieved value based on metric_type
-        metric_type = instance["metric_type"]
-        target_value = instance["target_value"]
-        target_direction = instance["target_direction"]
+        metric_type = instance.get("metric_type", "hours")
+        target_value = instance.get("target_value", 0)
+        target_direction = instance.get("target_direction", "at_least")
 
         from repositories.actions_repo import ActionsRepository
         actions_repo = ActionsRepository()

--- a/tm_bot/services/planner_api_adapter.py
+++ b/tm_bot/services/planner_api_adapter.py
@@ -838,8 +838,9 @@ class PlannerAPIAdapter:
             result = []
             for t in templates_with_status:
                 status = "🔓 Unlocked" if t.get('unlocked', False) else "🔒 Locked"
-                metric = f"{t['target_value']}{'x' if t['metric_type'] == 'count' else 'h'}"
-                result.append(f"{status} - {t['title']} ({t['level']}) - {metric} - {t['category']}")
+                metric = f"{t.get('target_value', 0)}{'x' if t.get('metric_type') == 'count' else 'h'}"
+                level_part = f" ({t['level']})" if t.get('level') else ""
+                result.append(f"{status} - {t['title']}{level_part} - {metric} - {t.get('category', '')}")
             
             return "\n".join(result)
         except Exception as e:
@@ -857,15 +858,21 @@ class PlannerAPIAdapter:
             prerequisites = self.templates_repo.get_prerequisites(template_id)
             
             result = [f"Template: {template['title']}"]
-            result.append(f"Category: {template['category']}")
-            result.append(f"Level: {template['level']}")
+            result.append(f"Category: {template.get('category', '')}")
+            if template.get('level'):
+                result.append(f"Level: {template['level']}")
             result.append(f"Status: {'🔓 Unlocked' if unlock_status['unlocked'] else '🔒 Locked'}")
             if not unlock_status['unlocked']:
                 result.append(f"Lock reason: {unlock_status['lock_reason']}")
-            result.append(f"Why: {template['why']}")
-            result.append(f"Done means: {template['done']}")
-            result.append(f"Effort: {template['effort']}")
-            result.append(f"Target: {template['target_value']}{'x' if template['metric_type'] == 'count' else 'h'} ({template['target_direction']})")
+            desc = template.get('why') or template.get('description') or ''
+            if desc:
+                result.append(f"Description: {desc}")
+            if template.get('done'):
+                result.append(f"Done means: {template['done']}")
+            if template.get('effort'):
+                result.append(f"Effort: {template['effort']}")
+            target_dir = template.get('target_direction', 'at_least')
+            result.append(f"Target: {template.get('target_value', 0)}{'x' if template.get('metric_type') == 'count' else 'h'} ({target_dir})")
             
             if prerequisites:
                 result.append("Prerequisites:")

--- a/tm_bot/services/reports.py
+++ b/tm_bot/services/reports.py
@@ -105,10 +105,10 @@ class ReportsService:
                 
                 # Determine metric type and target
                 if instance:
-                    metric_type = instance['metric_type']
-                    target_value = instance['target_value']
-                    target_direction = instance['target_direction']
-                    template_kind = instance['template_kind']
+                    metric_type = instance.get('metric_type', 'hours')
+                    target_value = instance.get('target_value', 0)
+                    target_direction = instance.get('target_direction', 'at_least')
+                    template_kind = instance.get('template_kind', 'commitment')
                 else:
                     # Legacy promise: hours-based
                     metric_type = 'hours'


### PR DESCRIPTION
- Applied safer `get` methods when accessing dictionary values across several modules, providing fallback defaults.
- Enhanced schema validation with checks for optional tables/columns (`bot_tokens`, `bot_token_id`), adding clear logging and fallback behavior.
- Updated `BroadcastRepository` to handle scenarios where `bot_token_id` is absent in schema.
- Improved template and instance joins with adaptive SQL based on schema version.
- Updated LLM handler with better prompts for creating promises dynamically when templates are unavailable.
- Added new utility and logger usage across repositories for consistency and error handling.