### PR TITLE
Improve fallback route classification when router JSON parsing fails

### DIFF
--- a/tests/unit/test_router_heuristic_fallback.py
+++ b/tests/unit/test_router_heuristic_fallback.py
@@ -13,22 +13,30 @@ from llms.agent import (  # noqa: E402
 )
 
 
-def test_router_heuristic_fallback_is_engagement_for_transactional_phrase():
+def test_router_heuristic_fallback_detects_operator_for_transactional_phrase():
     route = _heuristic_route_decision_from_text("please add a promise to run 3 hours this week")
-    assert route.mode == "engagement"
-    assert route.reason == "parsing_failed_fallback"
+    assert route.mode == "operator"
+    assert route.reason == "keyword_operator_fallback"
 
 
-def test_router_heuristic_fallback_is_engagement_for_advice_phrase():
+def test_router_heuristic_fallback_detects_strategist_for_advice_phrase():
     route = _heuristic_route_decision_from_text("what should I focus on next week to improve progress?")
-    assert route.mode == "engagement"
-    assert route.reason == "parsing_failed_fallback"
+    assert route.mode == "strategist"
+    assert route.reason == "keyword_strategist_fallback"
 
 
-def test_router_heuristic_fallback_is_engagement_for_social_phrase():
+def test_router_heuristic_fallback_detects_social_for_social_phrase():
     route = _heuristic_route_decision_from_text("show me my followers and community feed")
-    assert route.mode == "engagement"
-    assert route.reason == "parsing_failed_fallback"
+    assert route.mode == "social"
+    assert route.reason == "keyword_social_fallback"
+
+
+
+
+def test_router_heuristic_fallback_detects_operator_for_persian_transactional_phrase():
+    route = _heuristic_route_decision_from_text("یه تسک جدید اضافه کن")
+    assert route.mode == "operator"
+    assert route.reason == "keyword_operator_fallback"
 
 
 def test_router_heuristic_fallback_is_engagement_for_short_casual_phrase():


### PR DESCRIPTION
### Motivation
- Make the router fallback behavior more useful when structured JSON routing output cannot be parsed by choosing a likely mode instead of always defaulting to `engagement`.
- Improve downstream behavior and telemetry so the agent can pick a more appropriate responder/planner pathway for short or malformed router outputs, including Persian-language inputs.

### Description
- Replaced the unconditional `engagement` fallback in `_heuristic_route_decision_from_text` with lightweight keyword heuristics checking English and Persian trigger words for `social`, `strategist`, and `operator` modes in `tm_bot/llms/agent.py`.
- Set fallback `confidence` to `medium` and `reason` to `keyword_*_fallback` for matched heuristics to aid telemetry and analysis.
- Preserved conservative behavior by returning `RouteDecision(mode="engagement", confidence="low", reason="parsing_failed_fallback")` when no markers match.
- Updated `tests/unit/test_router_heuristic_fallback.py` to assert the new heuristic outputs and added a Persian transactional test case.

### Testing
- Ran `pytest -q tests/unit/test_router_heuristic_fallback.py`, which failed to collect due to a missing dependency: `ModuleNotFoundError: No module named 'langchain_core'` in this environment.
- Ran `python -m py_compile tm_bot/llms/agent.py tests/unit/test_router_heuristic_fallback.py` which succeeded (syntax/compile check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9033d3188329ac4dc906a7153eee)