### PR TITLE
Add catch-all handler for unrouted commands

### DIFF
--- a/tm_bot/planner_bot.py
+++ b/tm_bot/planner_bot.py
@@ -1668,6 +1668,10 @@ class PlannerBot:
         self.application.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, self.dispatch)
         )
+        # Catch-all for commands not in COMMAND_ROUTE_MAP (e.g. /status in group chats)
+        self.application.add_handler(
+            MessageHandler(filters.COMMAND, self.dispatch)
+        )
         self.application.add_handler(MessageHandler(filters.LOCATION, self.dispatch))
         self.application.add_handler(MessageHandler(filters.VOICE, self.dispatch))
         self.application.add_handler(


### PR DESCRIPTION
## Summary
Added a catch-all message handler to process commands that are not explicitly defined in the command route map, ensuring they are properly dispatched rather than being silently ignored.

## Key Changes
- Added a new `MessageHandler` that catches all `COMMAND` type messages and routes them through the `dispatch` method
- This handler is positioned after the text message handler to ensure proper precedence
- Includes a comment explaining the purpose: to handle commands like `/status` in group chats that may not have explicit routes defined

## Implementation Details
The new handler uses `filters.COMMAND` to match any message starting with `/` that isn't already handled by more specific command handlers. By routing these through the existing `dispatch` method, unrouted commands will be processed consistently with other message types, allowing the dispatch logic to determine the appropriate response (e.g., returning an error message or ignoring the command gracefully).

https://claude.ai/code/session_01Mw69iPB157F4BWoyRptVxn