### PR TITLE
tm_bot: fix /status command + improve Xaana group engagement with emoji reactions

### DIFF
--- a/tm_bot/llms/group_router.py
+++ b/tm_bot/llms/group_router.py
@@ -100,22 +100,23 @@ Output EXACTLY one JSON object on one line, nothing else:
 {"action": "...", "emoji": "...", "reason": "..."}
 
 action must be one of:
-- IGNORE: no response needed (side chatter, banter, off-topic, insults, mockery, repeated bait, stickers)
-- REACT_EMOJI: add a single emoji reaction to the message, no text (light achievements, quick social moments)
-- SHORT_REPLY: 1-2 sentence text reply (simple questions, mild engagement)
+- IGNORE: truly ignore — no reaction, no text (hostile content, insults, mockery, deliberate bait, repeated provocations)
+- REACT_EMOJI: add a single emoji reaction, no text (casual banter, side chatter, social moments, greetings, short acks — show presence without intruding)
+- SHORT_REPLY: 1-2 sentence text reply (simple questions, mild engagement, task completions worth a comment)
 - FULL_REPLY: full thoughtful response (direct club questions, complex situations, check-in info needed)
 
-emoji: pick an appropriate reaction for REACT_EMOJI (🔥 for achievements, 👍 for acks, ❤️ for support, 🎉 for milestones).
+emoji: pick a fitting reaction (🔥 achievements, 👍 acks, ❤️ support, 🎉 milestones, 👀 curious/watching, 😊 friendly, 💪 encouragement).
 reason: one short clause explaining the decision.
 
 Rules (in priority order):
-1. If the bot was NOT @mentioned AND message is not a task completion result → IGNORE almost always
-2. Emoji-only, sticker, short acks (ok, باشه, 😂, هاها, 👌) → IGNORE
-3. Identity bait, insults, mockery, "are you a robot?" → IGNORE (or one REACT_EMOJI at most)
+1. Insults, mockery, hostile content, deliberate identity bait → IGNORE (never reward hostility)
+2. Direct club question or task from @mention → FULL_REPLY
+3. Task completion (workout done, score, game result) → REACT_EMOJI if brief; SHORT_REPLY if they seem proud or want acknowledgment
 4. Fake facts or provocations about club stats → SHORT_REPLY to gently correct, nothing more
-5. Task completion (score, game result, workout done) → REACT_EMOJI if brief; SHORT_REPLY if they seem proud
-6. Direct club question from an @mention → FULL_REPLY
-7. Match vibe: quiet vibe → prefer IGNORE; playful vibe → allow SHORT_REPLY for social moments
+5. Casual banter, side chatter, greetings, short acks, emoji-only → REACT_EMOJI (show you're alive without interrupting)
+6. Off-topic but friendly conversation → REACT_EMOJI
+7. Match vibe: quiet vibe → prefer REACT_EMOJI over SHORT_REPLY; playful vibe → allow SHORT_REPLY for fun moments
+8. Default when unsure → REACT_EMOJI (presence > silence)
 """
 
 _USER_TEMPLATE = """Club vibe: {vibe}

--- a/tm_bot/planner_bot.py
+++ b/tm_bot/planner_bot.py
@@ -522,23 +522,18 @@ class PlannerBot:
                 await self._reply_with_group_club_info(ctx)
             return
 
+        # Skip non-text noise (stickers, gifs, etc. arrive as non-text update types)
+        if ctx.input_type != "text" or not (ctx.raw_text or "").strip():
+            return
+
         is_mentioned = await self._message_addresses_bot(ctx)
         is_completion = self._is_task_completion(ctx.raw_text or "")
-
-        # Only route if the message is relevant
-        if not is_mentioned and not is_completion:
-            return
 
         club = self._get_club_for_group_chat(ctx.chat_id)
         vibe = (club or {}).get("club_vibe") or "coach"
         club_id = (club or {}).get("club_id", "")
         ptb_context = getattr(ctx, "platform_context", None)
         bot_data = getattr(ptb_context, "bot_data", {}) if ptb_context else {}
-
-        # Check budget for spontaneous (proactive) messages
-        if not is_mentioned and not budget_allows(bot_data, ctx.chat_id, vibe, is_commanded=False):
-            logger.debug("group_router: budget exhausted for chat %s, skipping proactive response", ctx.chat_id)
-            return
 
         # Fetch member status once — used by router and LLM
         member_status = self._get_today_checkin_status(club_id) if club else []
@@ -548,7 +543,7 @@ class PlannerBot:
             for m in member_status
         )
 
-        # Call Groq router
+        # Call Groq router for every text message — it decides IGNORE/REACT_EMOJI/SHORT_REPLY/FULL_REPLY
         decision: RouterDecision = await asyncio.to_thread(
             route_group_message,
             ctx.raw_text or "",
@@ -568,7 +563,11 @@ class PlannerBot:
             await self._send_emoji_reaction(ctx, decision.emoji)
             return
 
-        # SHORT_REPLY or FULL_REPLY — hand off to LLM
+        # SHORT_REPLY or FULL_REPLY — budget gate applies only to text responses
+        if not is_mentioned and not budget_allows(bot_data, ctx.chat_id, vibe, is_commanded=False):
+            logger.debug("group_router: budget exhausted for chat %s, skipping proactive text response", ctx.chat_id)
+            return
+
         await asyncio.sleep(decision.delay_seconds)
         if is_mentioned:
             await self._handle_group_llm_message(

--- a/tm_bot/planner_bot.py
+++ b/tm_bot/planner_bot.py
@@ -1668,6 +1668,10 @@ class PlannerBot:
         self.application.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, self.dispatch)
         )
+        # Catch-all for commands not in COMMAND_ROUTE_MAP (e.g. /status in group chats)
+        self.application.add_handler(
+            MessageHandler(filters.COMMAND, self.dispatch)
+        )
         self.application.add_handler(MessageHandler(filters.LOCATION, self.dispatch))
         self.application.add_handler(MessageHandler(filters.VOICE, self.dispatch))
         self.application.add_handler(


### PR DESCRIPTION
## Summary

- **Fix `/status` command silently failing in group chats** — only commands in `COMMAND_ROUTE_MAP` had a `CommandHandler` registered; `/status` was dropped by python-telegram-bot before `dispatch()` was ever called. Added a catch-all `MessageHandler(filters.COMMAND, ...)` so unregistered group commands still reach `dispatch()`.
- **Make Xaana react to all group messages instead of going silent** — the early gate was dropping any message that wasn't an `@mention` or task completion, so most banter never reached the router. Now every non-empty text message goes through Groq; the response-budget gate was moved to only block text replies, not emoji reactions.
- **Update router prompt** — `REACT_EMOJI` is now the default for casual banter, greetings, and side chatter. `IGNORE` is reserved only for hostile/provocative content. Rule: *presence > silence*.

## Test plan

- [ ] Type `/status` in a connected group — should show the check-in card with member statuses and inline keyboard
- [ ] Type `/club` in a connected group — should still return club info card (unchanged)
- [ ] Send casual banter in the group (e.g. "lol", "nice", a greeting) — bot should react with an emoji instead of staying silent
- [ ] Send an insult or deliberate mockery — bot should stay completely silent (IGNORE)
- [ ] Send a task completion message (e.g. "just finished my run!") — bot should react with 🔥 or similar
- [ ] @mention the bot with a club question — bot should give a full reply as before
- [ ] Verify text-reply budget still works: after the daily limit of proactive text replies, bot should fall back to emoji reactions only (not text)

https://claude.ai/code/session_01Mw69iPB157F4BWoyRptVxn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw69iPB157F4BWoyRptVxn)_