### PR TITLE
feat: store and use dual-script name variants for club members

### DIFF
--- a/tm_bot/db/alembic/versions/018_add_multilingual_names.py
+++ b/tm_bot/db/alembic/versions/018_add_multilingual_names.py
@@ -1,0 +1,28 @@
+"""Add non_latin_name and latin_name columns to users table
+
+Revision ID: 018_add_multilingual_names
+Revises: 017_add_broadcast_media_fields
+Create Date: 2026-04-24
+
+Stores curated alternative-script name variants so the bot can recognise
+club members regardless of whether a message uses Latin or non-Latin script.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '018_add_multilingual_names'
+down_revision: Union[str, None] = '017_add_broadcast_media_fields'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('non_latin_name', sa.Text(), nullable=True))
+    op.add_column('users', sa.Column('latin_name', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'latin_name')
+    op.drop_column('users', 'non_latin_name')

--- a/tm_bot/planner_bot.py
+++ b/tm_bot/planner_bot.py
@@ -539,7 +539,11 @@ class PlannerBot:
         member_status = self._get_today_checkin_status(club_id) if club else []
         sender_name = ctx.metadata.get("sender_name") or ""
         sender_checked_in = any(
-            m.get("name") == sender_name and m.get("status") == "done"
+            m.get("status") == "done" and sender_name and (
+                m.get("name") == sender_name
+                or (m.get("non_latin_name") and m["non_latin_name"] == sender_name)
+                or (m.get("latin_name") and m["latin_name"] == sender_name)
+            )
             for m in member_status
         )
 
@@ -895,6 +899,8 @@ class PlannerBot:
             return [
                 {
                     "name": _display_name(m),
+                    "non_latin_name": (m.get("non_latin_name") or "").strip(),
+                    "latin_name": (m.get("latin_name") or "").strip(),
                     "status": "done" if str(m["user_id"]) in checked_in else "pending",
                 }
                 for m in raw_members

--- a/tm_bot/repositories/clubs_repo.py
+++ b/tm_bot/repositories/clubs_repo.py
@@ -458,6 +458,8 @@ class ClubsRepository:
                         cm.user_id,
                         u.first_name,
                         u.username,
+                        u.non_latin_name,
+                        u.latin_name,
                         p.text AS promise_text,
                         p.promise_uuid
                     FROM club_members cm

--- a/tm_bot/services/club_reminder_service.py
+++ b/tm_bot/services/club_reminder_service.py
@@ -41,10 +41,14 @@ CLUB_CHECKIN_PREFIX = "club_checkin:"
 # ---------------------------------------------------------------------------
 
 def _display_name(member: dict) -> str:
-    """Return the best available display name for a club member."""
-    first = (member.get("first_name") or "").strip()
+    """Return the best display name for a club member, combining both scripts when available."""
+    non_latin = (member.get("non_latin_name") or "").strip()
+    latin = (member.get("latin_name") or "").strip()
+    if non_latin and latin:
+        return f"{non_latin} / {latin}"
+    primary = non_latin or latin or (member.get("first_name") or "").strip()
     username = (member.get("username") or "").strip()
-    return first or (f"@{username}" if username else "Member")
+    return primary or (f"@{username}" if username else "Member")
 
 
 def _owner_timezone(owner_user_id: str) -> str:

--- a/tm_bot/webapp/routers/admin.py
+++ b/tm_bot/webapp/routers/admin.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, HTTPException, Query, Depends, Request, UploadFil
 from fastapi.responses import StreamingResponse, Response
 from ..dependencies import get_current_user, get_admin_user
 from ..schemas import (
-    AdminUsersResponse, CreateBroadcastRequest, UpdateBroadcastRequest,
+    AdminUsersResponse, AdminUserUpdateRequest, CreateBroadcastRequest, UpdateBroadcastRequest,
     BroadcastResponse, BotTokenResponse, ConversationResponse, ConversationMessage,
     GenerateTemplateRequest, CreatePromiseForUserRequest, DayReminder,
     RunTestsRequest, TestRunResponse, TestReportResponse,
@@ -629,11 +629,13 @@ async def get_admin_users(
         with get_db_session() as session:
             rows = session.execute(
                 text("""
-                    SELECT 
+                    SELECT
                         u.user_id,
                         u.first_name,
                         u.last_name,
                         u.username,
+                        u.non_latin_name,
+                        u.latin_name,
                         u.last_seen_utc,
                         u.timezone,
                         u.language,
@@ -667,6 +669,8 @@ async def get_admin_users(
                     first_name=row.get("first_name"),
                     last_name=row.get("last_name"),
                     username=row.get("username"),
+                    non_latin_name=row.get("non_latin_name"),
+                    latin_name=row.get("latin_name"),
                     last_seen_utc=row.get("last_seen_utc"),
                     timezone=row.get("timezone"),
                     language=row.get("language"),
@@ -676,12 +680,68 @@ async def get_admin_users(
             )
 
         return AdminUsersResponse(users=users, total=len(users))
-            
+
     except HTTPException:
         raise
     except Exception as e:
         logger.exception(f"Error getting admin users: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to fetch users: {str(e)}")
+
+
+@router.patch("/users/{user_id}")
+async def update_admin_user(
+    user_id: str,
+    body: AdminUserUpdateRequest,
+    admin_id: int = Depends(get_admin_user),
+):
+    """Update curated multilingual name fields for a user (admin only)."""
+    try:
+        now = utc_now_iso()
+        fields: dict = {}
+        if body.non_latin_name is not None:
+            fields["non_latin_name"] = body.non_latin_name.strip() or None
+        if body.latin_name is not None:
+            fields["latin_name"] = body.latin_name.strip() or None
+
+        if not fields:
+            raise HTTPException(status_code=400, detail="No fields provided to update.")
+
+        set_clause = ", ".join(f"{k} = :{k}" for k in fields)
+        params = {"user_id": user_id, "updated_at_utc": now, **fields}
+
+        with get_db_session() as session:
+            result = session.execute(
+                text(f"""
+                    UPDATE users
+                    SET {set_clause}, updated_at_utc = :updated_at_utc
+                    WHERE user_id = :user_id
+                    RETURNING user_id, first_name, last_name, username, non_latin_name, latin_name,
+                              last_seen_utc, timezone, language
+                """),
+                params,
+            ).mappings().fetchone()
+
+        if not result:
+            raise HTTPException(status_code=404, detail="User not found.")
+
+        from ..schemas import AdminUser
+        return AdminUser(
+            user_id=str(result["user_id"]),
+            first_name=result.get("first_name"),
+            last_name=result.get("last_name"),
+            username=result.get("username"),
+            non_latin_name=result.get("non_latin_name"),
+            latin_name=result.get("latin_name"),
+            last_seen_utc=result.get("last_seen_utc"),
+            timezone=result.get("timezone"),
+            language=result.get("language"),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error updating user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to update user: {str(e)}")
 
 
 @router.get("/bot-tokens", response_model=List[BotTokenResponse])

--- a/tm_bot/webapp/schemas.py
+++ b/tm_bot/webapp/schemas.py
@@ -306,6 +306,8 @@ class AdminUser(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     username: Optional[str] = None
+    non_latin_name: Optional[str] = None
+    latin_name: Optional[str] = None
     last_seen_utc: Optional[str] = None
     timezone: Optional[str] = None
     language: Optional[str] = None
@@ -317,6 +319,12 @@ class AdminUsersResponse(BaseModel):
     """Response model for admin users endpoint."""
     users: List[AdminUser]
     total: int
+
+
+class AdminUserUpdateRequest(BaseModel):
+    """Request model for updating curated name fields on a user (admin only)."""
+    non_latin_name: Optional[str] = None
+    latin_name: Optional[str] = None
 
 
 class CreateBroadcastRequest(BaseModel):

--- a/webapp_frontend/src/api/client.ts
+++ b/webapp_frontend/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   AdminClubSetupResponse,
   AdminClubSetupSummary,
   AdminUsersResponse,
+  AdminUser,
   Broadcast,
   CreateBroadcastRequest,
   UpdateBroadcastRequest,
@@ -490,6 +491,16 @@ class ApiClient {
    */
   async getAdminUsers(limit: number = 1000): Promise<AdminUsersResponse> {
     return this.request<AdminUsersResponse>(`/admin/users?limit=${limit}`);
+  }
+
+  async updateAdminUser(
+    userId: string,
+    body: { non_latin_name?: string | null; latin_name?: string | null },
+  ): Promise<AdminUser> {
+    return this.request<AdminUser>(`/admin/users/${encodeURIComponent(userId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    });
   }
 
   async getAdminClubTelegramSetup(status: 'pending' | 'ready' | 'all' = 'pending'): Promise<AdminClubSetupResponse> {

--- a/webapp_frontend/src/components/AdminPanel.tsx
+++ b/webapp_frontend/src/components/AdminPanel.tsx
@@ -17,6 +17,7 @@ import {
   TestsTab,
   FollowGraphTab,
   ClubsTelegramSetupTab,
+  UsersTab,
 } from './admin';
 
 export function AdminPanel() {
@@ -295,6 +296,18 @@ export function AdminPanel() {
 
       {activeTab === 'tests' && (
         <TestsTab />
+      )}
+
+      {activeTab === 'users' && (
+        <UsersTab
+          users={users}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          onUsersChange={(updated) =>
+            setUsers((prev) => prev.map((u) => (u.user_id === updated.user_id ? { ...u, ...updated } : u)))
+          }
+          onError={setError}
+        />
       )}
     </div>
   );

--- a/webapp_frontend/src/components/admin/AdminTabs.tsx
+++ b/webapp_frontend/src/components/admin/AdminTabs.tsx
@@ -9,7 +9,8 @@ export type TabType =
   | 'devtools'
   | 'createPromise'
   | 'conversations'
-  | 'tests';
+  | 'tests'
+  | 'users';
 
 interface AdminTabsProps {
   activeTab: TabType;
@@ -29,6 +30,7 @@ export function AdminTabs({ activeTab, onTabChange, scheduledCount }: AdminTabsP
       items: [
         { key: 'stats', label: 'Metrics' },
         { key: 'followgraph', label: 'Follow Graph' },
+        { key: 'users', label: 'Users' },
       ],
     },
     {

--- a/webapp_frontend/src/components/admin/UsersTab.tsx
+++ b/webapp_frontend/src/components/admin/UsersTab.tsx
@@ -1,0 +1,236 @@
+import { useState, useMemo } from 'react';
+import { apiClient, ApiError } from '../../api/client';
+import type { AdminUser } from '../../types';
+
+interface UsersTabProps {
+  users: AdminUser[];
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  onUsersChange: (updatedUser: AdminUser) => void;
+  onError: (error: string) => void;
+}
+
+interface EditState {
+  non_latin_name: string;
+  latin_name: string;
+}
+
+export function UsersTab({ users, searchQuery, setSearchQuery, onUsersChange, onError }: UsersTabProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editState, setEditState] = useState<EditState>({ non_latin_name: '', latin_name: '' });
+  const [saving, setSaving] = useState(false);
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.toLowerCase();
+    if (!q) return users;
+    return users.filter(
+      (u) =>
+        (u.first_name || '').toLowerCase().includes(q) ||
+        (u.last_name || '').toLowerCase().includes(q) ||
+        (u.username || '').toLowerCase().includes(q) ||
+        (u.non_latin_name || '').includes(searchQuery) ||
+        (u.latin_name || '').toLowerCase().includes(q) ||
+        u.user_id.includes(q),
+    );
+  }, [users, searchQuery]);
+
+  const startEdit = (user: AdminUser) => {
+    setEditingId(user.user_id);
+    setEditState({
+      non_latin_name: user.non_latin_name || '',
+      latin_name: user.latin_name || '',
+    });
+    onError('');
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+  };
+
+  const saveEdit = async (userId: string) => {
+    setSaving(true);
+    onError('');
+    try {
+      const updated = await apiClient.updateAdminUser(userId, {
+        non_latin_name: editState.non_latin_name || null,
+        latin_name: editState.latin_name || null,
+      });
+      onUsersChange(updated);
+      setEditingId(null);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        onError(err.message || 'Failed to save user names.');
+      } else {
+        onError('Failed to save user names.');
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const displayName = (u: AdminUser) =>
+    [u.first_name, u.last_name].filter(Boolean).join(' ') || u.username || u.user_id;
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Search by name, username, or ID…"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          style={{
+            width: '100%',
+            padding: '0.6rem 0.8rem',
+            background: 'rgba(255,255,255,0.07)',
+            border: '1px solid rgba(255,255,255,0.15)',
+            borderRadius: '8px',
+            color: '#e8eeff',
+            fontSize: '0.9rem',
+            boxSizing: 'border-box',
+          }}
+        />
+      </div>
+
+      <div style={{ fontSize: '0.8rem', color: 'rgba(232,238,252,0.5)', marginBottom: '0.75rem' }}>
+        {filtered.length} / {users.length} users — click Edit to set non-Latin / Latin name variants
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        {filtered.map((user) => {
+          const isEditing = editingId === user.user_id;
+          return (
+            <div
+              key={user.user_id}
+              style={{
+                background: 'rgba(15, 23, 48, 0.7)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                borderRadius: '10px',
+                padding: '0.75rem 1rem',
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.5rem' }}>
+                <div>
+                  <span style={{ fontWeight: 600, color: '#e8eeff' }}>{displayName(user)}</span>
+                  {user.username && (
+                    <span style={{ marginLeft: '0.5rem', color: 'rgba(232,238,252,0.5)', fontSize: '0.85rem' }}>
+                      @{user.username}
+                    </span>
+                  )}
+                  <span style={{ marginLeft: '0.5rem', color: 'rgba(232,238,252,0.3)', fontSize: '0.75rem' }}>
+                    #{user.user_id}
+                  </span>
+                </div>
+                {!isEditing && (
+                  <button
+                    onClick={() => startEdit(user)}
+                    style={{
+                      padding: '0.3rem 0.7rem',
+                      background: 'rgba(99,102,241,0.2)',
+                      border: '1px solid rgba(99,102,241,0.4)',
+                      borderRadius: '6px',
+                      color: '#a5b4fc',
+                      cursor: 'pointer',
+                      fontSize: '0.8rem',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Edit names
+                  </button>
+                )}
+              </div>
+
+              {!isEditing && (user.non_latin_name || user.latin_name) && (
+                <div style={{ marginTop: '0.4rem', fontSize: '0.85rem', color: 'rgba(232,238,252,0.6)' }}>
+                  {user.non_latin_name && <span>{user.non_latin_name}</span>}
+                  {user.non_latin_name && user.latin_name && (
+                    <span style={{ margin: '0 0.4rem', opacity: 0.4 }}>/</span>
+                  )}
+                  {user.latin_name && <span>{user.latin_name}</span>}
+                </div>
+              )}
+
+              {isEditing && (
+                <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                  <label style={{ fontSize: '0.8rem', color: 'rgba(232,238,252,0.6)' }}>
+                    Non-Latin name (e.g. سپیده)
+                    <input
+                      type="text"
+                      value={editState.non_latin_name}
+                      onChange={(e) => setEditState((s) => ({ ...s, non_latin_name: e.target.value }))}
+                      dir="auto"
+                      style={{
+                        display: 'block',
+                        width: '100%',
+                        marginTop: '0.25rem',
+                        padding: '0.45rem 0.7rem',
+                        background: 'rgba(255,255,255,0.07)',
+                        border: '1px solid rgba(255,255,255,0.2)',
+                        borderRadius: '6px',
+                        color: '#e8eeff',
+                        fontSize: '0.9rem',
+                        boxSizing: 'border-box',
+                      }}
+                    />
+                  </label>
+                  <label style={{ fontSize: '0.8rem', color: 'rgba(232,238,252,0.6)' }}>
+                    Latin name (e.g. Sepideh Hemmatan)
+                    <input
+                      type="text"
+                      value={editState.latin_name}
+                      onChange={(e) => setEditState((s) => ({ ...s, latin_name: e.target.value }))}
+                      style={{
+                        display: 'block',
+                        width: '100%',
+                        marginTop: '0.25rem',
+                        padding: '0.45rem 0.7rem',
+                        background: 'rgba(255,255,255,0.07)',
+                        border: '1px solid rgba(255,255,255,0.2)',
+                        borderRadius: '6px',
+                        color: '#e8eeff',
+                        fontSize: '0.9rem',
+                        boxSizing: 'border-box',
+                      }}
+                    />
+                  </label>
+                  <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.25rem' }}>
+                    <button
+                      onClick={() => saveEdit(user.user_id)}
+                      disabled={saving}
+                      style={{
+                        padding: '0.4rem 1rem',
+                        background: saving ? 'rgba(99,102,241,0.1)' : 'rgba(99,102,241,0.3)',
+                        border: '1px solid rgba(99,102,241,0.5)',
+                        borderRadius: '6px',
+                        color: '#a5b4fc',
+                        cursor: saving ? 'not-allowed' : 'pointer',
+                        fontSize: '0.85rem',
+                      }}
+                    >
+                      {saving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      onClick={cancelEdit}
+                      disabled={saving}
+                      style={{
+                        padding: '0.4rem 1rem',
+                        background: 'transparent',
+                        border: '1px solid rgba(255,255,255,0.15)',
+                        borderRadius: '6px',
+                        color: 'rgba(232,238,252,0.5)',
+                        cursor: 'pointer',
+                        fontSize: '0.85rem',
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/webapp_frontend/src/components/admin/index.ts
+++ b/webapp_frontend/src/components/admin/index.ts
@@ -14,3 +14,4 @@ export { TemplateForm } from './TemplateForm';
 export { DeleteConfirmModal } from './DeleteConfirmModal';
 export { UserSelector } from './UserSelector';
 export { FollowGraphTab } from './FollowGraphTab';
+export { UsersTab } from './UsersTab';

--- a/webapp_frontend/src/types.ts
+++ b/webapp_frontend/src/types.ts
@@ -237,6 +237,8 @@ export interface AdminUser {
   first_name?: string;
   last_name?: string;
   username?: string;
+  non_latin_name?: string;
+  latin_name?: string;
   last_seen_utc?: string;
   timezone?: string;
   language?: string;


### PR DESCRIPTION
Adds non_latin_name and latin_name columns to the users table so admins
can curate both script forms for each member. The bot now surfaces both
variants when building the LLM context for group messages, and the
sender_checked_in detection matches against either variant so check-in
state is correctly attributed regardless of which script a user sends
their name in.

Changes:
- DB migration 018: add non_latin_name + latin_name columns to users
- clubs_repo: include both new columns in get_club_members_promises query
- _display_name(): returns "Non-Latin / Latin" when both variants are set
- _get_today_checkin_status(): includes non_latin_name + latin_name in
  each member dict so the LLM sees both for matching
- sender_checked_in: checks all three name variants (display, non-latin,
  latin) to avoid false "not checked in" when scripts differ
- admin PATCH /admin/users/{user_id}: lets admins set both name fields
- admin GET /admin/users: now returns the two new name fields
- AdminUserUpdateRequest schema + AdminUser schema updated
- Frontend: new Users tab in admin panel with inline edit for both name
  fields, search across all name variants, optimistic update on save

https://claude.ai/code/session_01FZ1mJVdAi8ZEezDVFSWsDV