### PR TITLE
feat: show planned sessions in home view cards and fix week-aware status tags

### DIFF
--- a/tm_bot/repositories/plan_sessions_repo.py
+++ b/tm_bot/repositories/plan_sessions_repo.py
@@ -237,6 +237,32 @@ class PlanSessionsRepository:
             checklist = self._get_checklist(session, result["id"])
             return {**dict(result), "checklist": checklist}
 
+    def list_planned_by_promise_uuids(self, promise_uuids: List[str], user_id: int) -> dict:
+        """Bulk-fetch all planned sessions for a list of promise_uuids, grouped by promise_uuid."""
+        if not promise_uuids:
+            return {}
+        user = str(user_id)
+        with get_db_session() as session:
+            rows = session.execute(
+                text("""
+                    SELECT id, promise_uuid, title, status,
+                           planned_start, planned_duration_min, notes, created_at
+                    FROM plan_sessions
+                    WHERE promise_uuid = ANY(:uuids) AND user_id = :user_id
+                      AND status = 'planned'
+                    ORDER BY planned_start NULLS LAST, created_at
+                """),
+                {"uuids": promise_uuids, "user_id": user},
+            ).mappings().fetchall()
+
+        result: dict = {}
+        for r in rows:
+            uuid = r["promise_uuid"]
+            if uuid not in result:
+                result[uuid] = []
+            result[uuid].append(dict(r))
+        return result
+
     def list_upcoming_for_user(self, user_id: int, since_iso: str, until_iso: str) -> List[dict]:
         """List all planned sessions for a user between two ISO datetime strings.
 

--- a/tm_bot/services/reports.py
+++ b/tm_bot/services/reports.py
@@ -9,6 +9,7 @@ from repositories.promises_repo import PromisesRepository
 from repositories.actions_repo import ActionsRepository
 from repositories.instances_repo import InstancesRepository
 from repositories.distractions_repo import DistractionsRepository
+from repositories.plan_sessions_repo import PlanSessionsRepository
 from utils.time_utils import get_week_range
 from utils.promise_id import normalize_promise_id, promise_ids_equal
 from db.postgres_db import resolve_promise_uuid, get_db_session
@@ -277,7 +278,23 @@ class ReportsService:
                 promise_data['hours_spent'] = total_hours
             
             promise_data['sessions'] = sessions
-        
+
+        # Attach planned session counts for all promises in the report
+        uuids = [promise_uuid_by_id[pid] for pid in report_data if pid in promise_uuid_by_id]
+        planned_by_uuid = PlanSessionsRepository().list_planned_by_promise_uuids(uuids, user_id)
+        for promise_id, promise_data in report_data.items():
+            p_uuid = promise_uuid_by_id.get(promise_id)
+            sessions_list = planned_by_uuid.get(p_uuid, []) if p_uuid else []
+            promise_data['planned_sessions_count'] = len(sessions_list)
+            next_s = sessions_list[0] if sessions_list else None
+            if next_s and next_s.get('planned_start'):
+                raw = next_s['planned_start']
+                promise_data['next_session_start'] = (
+                    raw.isoformat() if hasattr(raw, 'isoformat') else str(raw)
+                )
+            else:
+                promise_data['next_session_start'] = None
+
         return report_data
 
     def get_promise_summary(self, user_id: int, promise_id: str, ref_time: datetime) -> Dict[str, Any]:

--- a/webapp_frontend/src/components/PromiseCardV2.tsx
+++ b/webapp_frontend/src/components/PromiseCardV2.tsx
@@ -1,4 +1,4 @@
-﻿import type { HTMLAttributes, KeyboardEvent } from 'react';
+import type { HTMLAttributes, KeyboardEvent } from 'react';
 import type { PromiseData } from '../types';
 import { Badge } from './ui/Badge';
 import { formatPromiseText } from '../utils/activityFormat';
@@ -10,17 +10,42 @@ interface PromiseCardV2Props {
   onOpenDetail: () => void;
 }
 
-function getStatusClass(progress: number): 'good' | 'warn' | 'bad' | '' {
-  if (progress >= 60) return 'good';
-  if (progress >= 30) return 'warn';
-  if (progress > 0) return 'bad';
-  return '';
+function toLocalDateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 }
 
-function getStatusLabel(progress: number): string {
-  if (progress >= 60) return 'On track';
-  if (progress >= 30) return 'Behind';
-  return 'At risk';
+// Returns expected progress fraction (0-1) based on today's position in the week.
+// Returns 1.0 for past weeks (today is not in weekDays).
+function weekExpectedFraction(weekDays: string[]): number {
+  const todayKey = toLocalDateKey(new Date());
+  const idx = weekDays.indexOf(todayKey);
+  return idx >= 0 ? (idx + 1) / 7 : 1.0;
+}
+
+function getStatusInfo(
+  progress: number,
+  expectedFraction: number,
+): { label: string; cls: 'good' | 'warn' | 'bad' | '' } {
+  const expected = expectedFraction * 100;
+  if (progress >= expected) return { label: 'On track', cls: 'good' };
+  if (progress >= expected * 0.5) return { label: 'Behind', cls: 'warn' };
+  if (progress > 0) return { label: 'At risk', cls: 'bad' };
+  return { label: 'At risk', cls: '' };
+}
+
+function formatNextSession(isoStr: string): string {
+  const dt = new Date(isoStr);
+  if (Number.isNaN(dt.getTime())) return '';
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1);
+  const dtDay = new Date(dt);
+  dtDay.setHours(0, 0, 0, 0);
+  const time = dt.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+  if (dtDay.getTime() === today.getTime()) return `Today ${time}`;
+  if (dtDay.getTime() === tomorrow.getTime()) return `Tomorrow ${time}`;
+  return dt.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
 export function PromiseCardV2({ id, data, weekDays, onOpenDetail }: PromiseCardV2Props) {
@@ -34,6 +59,8 @@ export function PromiseCardV2({ id, data, weekDays, onOpenDetail }: PromiseCardV
     template_kind = 'commitment',
     achieved_value = hours_spent,
     recurring = true,
+    planned_sessions_count = 0,
+    next_session_start,
   } = data;
 
   const isCountBased = metric_type === 'count';
@@ -41,7 +68,8 @@ export function PromiseCardV2({ id, data, weekDays, onOpenDetail }: PromiseCardV
   const target = target_value || hours_promised || 1;
   const achieved = achieved_value ?? hours_spent ?? 0;
   const progress = target > 0 ? Math.min(Math.round((achieved / target) * 100), 100) : 0;
-  const statusClass = getStatusClass(progress);
+  const expectedFraction = weekExpectedFraction(weekDays);
+  const { label: statusLabel, cls: statusClass } = getStatusInfo(progress, expectedFraction);
 
   const sessionsByDate: Record<string, number> = {};
   sessions.forEach((session) => {
@@ -55,6 +83,12 @@ export function PromiseCardV2({ id, data, weekDays, onOpenDetail }: PromiseCardV
   });
 
   const checkinDays = weekDays.map((date) => (sessionsByDate[date] || 0) > 0);
+
+  const sessionsLabel = planned_sessions_count > 0
+    ? (next_session_start
+        ? formatNextSession(next_session_start)
+        : `${planned_sessions_count} session${planned_sessions_count > 1 ? 's' : ''}`)
+    : null;
 
   return (
     <article
@@ -75,7 +109,7 @@ export function PromiseCardV2({ id, data, weekDays, onOpenDetail }: PromiseCardV
           <span className="pid" dir="ltr">#{id}</span>
         </DTitle>
         <Badge variant={statusClass || 'neutral'} showDot>
-          {getStatusLabel(progress)}
+          {statusLabel}
         </Badge>
       </DTop>
       {isCountBased && recurring ? (
@@ -95,7 +129,13 @@ export function PromiseCardV2({ id, data, weekDays, onOpenDetail }: PromiseCardV
             ? `${Math.round(achieved)}/${Math.round(target)} check-ins`
             : `${achieved.toFixed(1)}h / ${target.toFixed(1)}h`}
         </span>
-        <span className="meta" dir="ltr">{progress}%</span>
+        {sessionsLabel ? (
+          <span className="sessions-chip" dir="ltr" aria-label={`${planned_sessions_count} planned session${planned_sessions_count > 1 ? 's' : ''}`}>
+            &#x1F4C5; {sessionsLabel}
+          </span>
+        ) : (
+          <span className="meta" dir="ltr">{progress}%</span>
+        )}
       </DRow>
     </article>
   );

--- a/webapp_frontend/src/components/WeeklyReport.tsx
+++ b/webapp_frontend/src/components/WeeklyReport.tsx
@@ -97,12 +97,18 @@ export function WeeklyReport({
         const aActive = aValue > 0 ? 1 : 0;
         const bActive = bValue > 0 ? 1 : 0;
         if (bActive !== aActive) return bActive - aActive; // active first
-        // within each group keep alphabetical order
         return a[0].localeCompare(b[0]);
       });
       return entries;
     }
-    return entries.sort((a, b) => a[0].localeCompare(b[0]));
+    // Current week: promises with upcoming planned sessions float to the top
+    entries.sort((a, b) => {
+      const aHasSessions = (a[1].planned_sessions_count ?? 0) > 0 ? 1 : 0;
+      const bHasSessions = (b[1].planned_sessions_count ?? 0) > 0 ? 1 : 0;
+      if (bHasSessions !== aHasSessions) return bHasSessions - aHasSessions;
+      return a[0].localeCompare(b[0]);
+    });
+    return entries;
   }, [promises, isPastWeek]);
 
   // Capped total: each promise contributes at most its own target.

--- a/webapp_frontend/src/styles/sheets.css
+++ b/webapp_frontend/src/styles/sheets.css
@@ -289,6 +289,13 @@
 .pcard.bad  .progress .fill { background: var(--bad-500); }
 .pcard .row { display: flex; justify-content: space-between; align-items: center; }
 .pcard .row .sub { font-size: 11px; color: var(--fg-subtle); }
+.pcard .row .sessions-chip {
+  font-size: 11px;
+  color: var(--accent);
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0.85;
+}
 
 .list { display: grid; gap: 10px; }
 

--- a/webapp_frontend/src/types.ts
+++ b/webapp_frontend/src/types.ts
@@ -105,8 +105,15 @@ export interface PromiseData {
   sessions: SessionData[];
   visibility?: string; // "private" | "public"
   recurring?: boolean;
+  metric_type?: 'hours' | 'count';
+  target_value?: number;
+  target_direction?: 'at_least' | 'at_most';
+  template_kind?: 'commitment' | 'budget';
+  achieved_value?: number;
   start_date?: string; // ISO date string (YYYY-MM-DD)
   end_date?: string; // ISO date string (YYYY-MM-DD)
+  planned_sessions_count?: number;
+  next_session_start?: string | null;
 }
 
 export interface WeeklyReportData {


### PR DESCRIPTION
- Backend: add PlanSessionsRepository.list_planned_by_promise_uuids() for
  efficient bulk fetch, then attach planned_sessions_count + next_session_start
  to every promise in the weekly report response
- Frontend types: add planned_sessions_count, next_session_start and the
  previously-missing metric_type / target_value / template_kind / achieved_value
  fields to PromiseData
- PromiseCardV2: replace fixed 60/30 thresholds with day-aware expected
  progress (current weekday ÷ 7) so early-week cards aren't wrongly flagged
  as Behind/At risk; show a calendar chip with the next session time (or count)
  in the card footer when planned sessions exist
- WeeklyReport: for the current week, float promises that have upcoming
  planned sessions to the top of the list

Closes #66