### PR TITLE
Add backend club leaderboard scoring

### DIFF
--- a/tests/webapp/test_club_leaderboard.py
+++ b/tests/webapp/test_club_leaderboard.py
@@ -1,0 +1,188 @@
+from datetime import date
+
+from webapp.routers.community import _rank_club_leaderboard_members
+
+
+TODAY = date(2026, 5, 28)
+
+
+def _member(user_id: str, name: str) -> dict:
+    return {"user_id": user_id, "first_name": name, "username": None, "avatar_path": None}
+
+
+def _count_promise(uuid: str = "p-count", target: float = 7.0) -> dict:
+    return {
+        "promise_uuid": uuid,
+        "promise_text": "Play Cheenva",
+        "metric_type": "count",
+        "target_value": target,
+    }
+
+
+def _hours_promise(uuid: str = "p-hours", target: float = 4.0) -> dict:
+    return {
+        "promise_uuid": uuid,
+        "promise_text": "Deep work",
+        "metric_type": "hours",
+        "target_value": target,
+    }
+
+
+def test_count_leaderboard_orders_by_rolling_active_days_then_latest_activity():
+    members = [
+        _member("sepideh", "Sepideh"),
+        _member("javad", "Javad"),
+        _member("homa", "Homa"),
+        _member("marzieh", "Marzieh"),
+        _member("aa", "AA"),
+    ]
+    promise = _count_promise()
+    days = [date(2026, 5, day) for day in range(22, 29)]
+    actions = {
+        ("sepideh", "p-count"): {
+            "active_days": set(days),
+            "checkin_count": 7,
+            "last_activity_at_utc": "2026-05-28T16:41:27+00:00",
+        },
+        ("javad", "p-count"): {
+            "active_days": set(days),
+            "checkin_count": 7,
+            "last_activity_at_utc": "2026-05-28T00:02:01+00:00",
+        },
+        ("homa", "p-count"): {
+            "active_days": set(days[:-1]),
+            "checkin_count": 6,
+            "last_activity_at_utc": "2026-05-27T21:52:44+00:00",
+        },
+        ("marzieh", "p-count"): {
+            "active_days": {date(2026, 5, 22), date(2026, 5, 25)},
+            "checkin_count": 2,
+            "last_activity_at_utc": "2026-05-25T15:16:22+00:00",
+        },
+    }
+
+    rows = _rank_club_leaderboard_members(
+        members=members,
+        promises=[promise],
+        actions_by_member_promise=actions,
+        today=TODAY,
+        limit=10,
+    )
+
+    assert [row.first_name for row in rows] == ["Sepideh", "Javad", "Homa", "Marzieh", "AA"]
+    assert [row.breakdown[0].achieved_value for row in rows] == [7, 7, 6, 2, 0]
+    assert rows[0].score_percent == 100
+    assert rows[1].score_percent == 100
+
+
+def test_duplicate_same_day_checkins_count_as_one_active_day():
+    rows = _rank_club_leaderboard_members(
+        members=[_member("u1", "User")],
+        promises=[_count_promise(target=7)],
+        actions_by_member_promise={
+            ("u1", "p-count"): {
+                "active_days": {TODAY},
+                "checkin_count": 2,
+                "last_activity_at_utc": "2026-05-28T12:00:00+00:00",
+            }
+        },
+        today=TODAY,
+        limit=10,
+    )
+
+    assert rows[0].breakdown[0].achieved_value == 1
+    assert rows[0].breakdown[0].checkin_count == 2
+    assert rows[0].score_percent == 14.3
+
+
+def test_log_time_does_not_count_as_binary_checkin_day():
+    rows = _rank_club_leaderboard_members(
+        members=[_member("u1", "User")],
+        promises=[_count_promise(target=7)],
+        actions_by_member_promise={
+            ("u1", "p-count"): {
+                "activity_days": {TODAY},
+                "checkin_days": set(),
+                "duration_hours": 2.0,
+                "last_activity_at_utc": "2026-05-28T12:00:00+00:00",
+            }
+        },
+        today=TODAY,
+        limit=10,
+    )
+
+    assert rows[0].active_days == 1
+    assert rows[0].breakdown[0].achieved_value == 0
+    assert rows[0].score_percent == 0
+
+
+def test_duration_promise_uses_logged_hours_over_target():
+    rows = _rank_club_leaderboard_members(
+        members=[_member("u1", "A"), _member("u2", "B")],
+        promises=[_hours_promise(target=4)],
+        actions_by_member_promise={
+            ("u1", "p-hours"): {
+                "active_days": {TODAY},
+                "duration_hours": 3.0,
+                "last_activity_at_utc": "2026-05-28T08:00:00+00:00",
+            },
+            ("u2", "p-hours"): {
+                "active_days": {TODAY},
+                "duration_hours": 1.0,
+                "last_activity_at_utc": "2026-05-28T09:00:00+00:00",
+            },
+        },
+        today=TODAY,
+        limit=10,
+    )
+
+    assert [row.first_name for row in rows] == ["A", "B"]
+    assert [row.score_percent for row in rows] == [75, 25]
+
+
+def test_mixed_promises_average_normalized_progress():
+    rows = _rank_club_leaderboard_members(
+        members=[_member("u1", "Balanced"), _member("u2", "Checkins")],
+        promises=[_count_promise(target=7), _hours_promise(target=4)],
+        actions_by_member_promise={
+            ("u1", "p-count"): {"active_days": {TODAY}, "checkin_count": 1},
+            ("u1", "p-hours"): {"active_days": {TODAY}, "duration_hours": 4.0},
+            ("u2", "p-count"): {
+                "active_days": {date(2026, 5, day) for day in range(22, 29)},
+                "checkin_count": 7,
+            },
+            ("u2", "p-hours"): {"active_days": set(), "duration_hours": 0.0},
+        },
+        today=TODAY,
+        limit=10,
+    )
+
+    assert rows[0].first_name == "Balanced"
+    assert rows[0].score_percent == 57.1
+    assert rows[1].first_name == "Checkins"
+    assert rows[1].score_percent == 50
+
+
+def test_unshared_or_inactive_member_actions_are_absent_from_inputs_and_do_not_count():
+    rows = _rank_club_leaderboard_members(
+        members=[_member("active", "Active")],
+        promises=[_count_promise()],
+        actions_by_member_promise={
+            ("other", "p-count"): {
+                "active_days": {TODAY},
+                "checkin_count": 1,
+                "last_activity_at_utc": "2026-05-28T10:00:00+00:00",
+            },
+            ("active", "private-promise"): {
+                "active_days": {TODAY},
+                "checkin_count": 1,
+                "last_activity_at_utc": "2026-05-28T11:00:00+00:00",
+            },
+        },
+        today=TODAY,
+        limit=10,
+    )
+
+    assert len(rows) == 1
+    assert rows[0].first_name == "Active"
+    assert rows[0].score_percent == 0

--- a/tm_bot/webapp/routers/community.py
+++ b/tm_bot/webapp/routers/community.py
@@ -2,7 +2,8 @@
 Community-related endpoints (suggestions, public promises, follows).
 """
 
-from datetime import datetime
+from collections import defaultdict
+from datetime import date, datetime, timedelta
 from typing import List, Optional
 import asyncio
 import json
@@ -19,6 +20,10 @@ from ..schemas import (
     AddClubPromiseRequest,
     ClubActionResponse,
     ClubContextIngestResponse,
+    ClubLeaderboardBreakdown,
+    ClubLeaderboardMember,
+    ClubLeaderboardPromiseSummary,
+    ClubLeaderboardResponse,
     ClubMemberSummary,
     CreateClubRequest,
     ClubsResponse,
@@ -50,6 +55,151 @@ logger = get_logger(__name__)
 
 
 CLUB_CONTEXT_FIELDS = {"description", "club_goal", "vibe", "checkin_what_counts"}
+
+
+def _date_key(value: object) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return date.fromisoformat(str(value)[:10])
+
+
+def _calculate_freeze_streak(activity_dates: list[date], today: date, freeze_budget: int = 2) -> int:
+    dates = sorted({d for d in activity_dates if d <= today}, reverse=True)
+    if not dates:
+        return 0
+
+    freezes_remaining = max(0, int(freeze_budget))
+    initial_missed_days = max(0, (today - dates[0]).days - 1)
+    if initial_missed_days > freezes_remaining:
+        return 0
+
+    freezes_remaining -= initial_missed_days
+    streak = 1
+    previous = dates[0]
+    for check_date in dates[1:]:
+        missed_days = max(0, (previous - check_date).days - 1)
+        if missed_days > freezes_remaining:
+            break
+        freezes_remaining -= missed_days
+        streak += 1
+        previous = check_date
+    return streak
+
+
+def _display_name_key(member: dict) -> str:
+    return str(
+        member.get("first_name")
+        or member.get("username")
+        or member.get("user_id")
+        or ""
+    ).lower()
+
+
+def _sort_timestamp_desc(value: Optional[str]) -> float:
+    if not value:
+        return 0.0
+    try:
+        return -datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _rank_club_leaderboard_members(
+    *,
+    members: list[dict],
+    promises: list[dict],
+    actions_by_member_promise: dict[tuple[str, str], dict],
+    today: date,
+    limit: int,
+) -> list[ClubLeaderboardMember]:
+    rows: list[ClubLeaderboardMember] = []
+    name_by_user: dict[str, str] = {}
+
+    for member in members:
+        user_id = str(member["user_id"])
+        name_by_user[user_id] = _display_name_key(member)
+        breakdown: list[ClubLeaderboardBreakdown] = []
+        activity_dates: set[date] = set()
+        last_activity_at_utc: Optional[str] = None
+        total_duration_hours = 0.0
+        total_checkins = 0
+
+        for promise in promises:
+            promise_uuid = str(promise["promise_uuid"])
+            metric_type = str(promise.get("metric_type") or "hours")
+            target_value = float(promise.get("target_value") or (7.0 if metric_type == "count" else 1.0))
+            stats = actions_by_member_promise.get((user_id, promise_uuid), {})
+            activity_days_set = set(stats.get("activity_days") or stats.get("active_days") or [])
+            checkin_days_set = set(stats.get("checkin_days") or stats.get("active_days") or [])
+            duration_hours = float(stats.get("duration_hours") or 0.0)
+            checkin_count = int(stats.get("checkin_count") or 0)
+            last_at = stats.get("last_activity_at_utc")
+
+            activity_dates.update(activity_days_set)
+            total_duration_hours += duration_hours
+            total_checkins += checkin_count
+            if last_at and (not last_activity_at_utc or str(last_at) > last_activity_at_utc):
+                last_activity_at_utc = str(last_at)
+
+            if metric_type == "count":
+                achieved_value = float(len(checkin_days_set))
+                active_days_count = len(checkin_days_set)
+            else:
+                achieved_value = duration_hours
+                active_days_count = len(activity_days_set)
+            progress_percent = min(round((achieved_value / target_value) * 100, 1), 100.0) if target_value > 0 else 0.0
+
+            breakdown.append(
+                ClubLeaderboardBreakdown(
+                    promise_uuid=promise_uuid,
+                    promise_text=str(promise.get("promise_text") or "Club promise"),
+                    metric_type=metric_type,
+                    target_value=target_value,
+                    achieved_value=round(achieved_value, 2),
+                    active_days=active_days_count,
+                    duration_hours=round(duration_hours, 2),
+                    checkin_count=checkin_count,
+                    progress_percent=progress_percent,
+                )
+            )
+
+        score_percent = (
+            round(sum(item.progress_percent for item in breakdown) / len(breakdown), 1)
+            if breakdown
+            else 0.0
+        )
+        rows.append(
+            ClubLeaderboardMember(
+                rank=0,
+                user_id=user_id,
+                first_name=str(member["first_name"]) if member.get("first_name") else None,
+                username=str(member["username"]) if member.get("username") else None,
+                avatar_path=str(member["avatar_path"]) if member.get("avatar_path") else None,
+                score_percent=score_percent,
+                active_days=len(activity_dates),
+                duration_hours=round(total_duration_hours, 2),
+                checkin_count=total_checkins,
+                freeze_streak=_calculate_freeze_streak(list(activity_dates), today),
+                last_activity_at_utc=last_activity_at_utc,
+                breakdown=breakdown,
+            )
+        )
+
+    rows.sort(
+        key=lambda row: (
+            -row.score_percent,
+            _sort_timestamp_desc(row.last_activity_at_utc),
+            -row.freeze_streak,
+            name_by_user.get(row.user_id, ""),
+        )
+    )
+
+    ranked = rows[:limit]
+    for index, row in enumerate(ranked, start=1):
+        row.rank = index
+    return ranked
 
 
 def _generate_club_promise_id(user_id: int) -> str:
@@ -166,6 +316,7 @@ def _list_user_clubs(user_id: int) -> List[ClubSummary]:
                     {telegram_invite_select},
                     cm.role,
                     COALESCE(member_counts.member_count, 0) AS member_count,
+                    COALESCE(promise_counts.promise_count, 0) AS promise_count,
                     p.current_id AS promise_id,
                     p.promise_uuid AS promise_uuid,
                     p.text AS promise_text,
@@ -187,6 +338,14 @@ def _list_user_clubs(user_id: int) -> List[ClubSummary]:
                     WHERE status = 'active'
                     GROUP BY club_id
                 ) member_counts ON member_counts.club_id = c.club_id
+                LEFT JOIN (
+                    SELECT pcs.club_id, COUNT(*) AS promise_count
+                    FROM promise_club_shares pcs
+                    JOIN promises p
+                      ON p.promise_uuid = pcs.promise_uuid
+                     AND p.is_deleted = 0
+                    GROUP BY pcs.club_id
+                ) promise_counts ON promise_counts.club_id = c.club_id
                 LEFT JOIN promise_club_shares pcs ON pcs.club_id = c.club_id
                 LEFT JOIN promises p
                     ON p.promise_uuid = pcs.promise_uuid
@@ -246,6 +405,7 @@ def _list_user_clubs(user_id: int) -> List[ClubSummary]:
             promise_id=str(row["promise_id"]) if row["promise_id"] else None,
             promise_uuid=str(row["promise_uuid"]) if row["promise_uuid"] else None,
             promise_text=str(row["promise_text"]) if row["promise_text"] else None,
+            promise_count=int(row["promise_count"] or 0),
             target_count_per_week=float(row["target_count_per_week"]) if row["target_count_per_week"] is not None else None,
             reminder_time=str(row["reminder_time"]) if row["reminder_time"] else None,
             language=str(row["language"]) if row["language"] else None,
@@ -460,6 +620,176 @@ async def list_my_clubs(user_id: int = Depends(get_current_user)):
     except Exception as e:
         logger.exception(f"Error listing clubs for user {user_id}: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to load clubs: {str(e)}")
+
+
+@router.get("/clubs/{club_id}/leaderboard", response_model=ClubLeaderboardResponse)
+async def get_club_leaderboard(
+    club_id: str,
+    window: str = Query(default="rolling_7d", pattern="^rolling_7d$"),
+    limit: int = Query(default=10, ge=1, le=10),
+    user_id: int = Depends(get_current_user),
+):
+    """Return a mixed rolling 7-day leaderboard across active shared club promises."""
+    user = str(user_id)
+    today = datetime.utcnow().date()
+    window_start = today - timedelta(days=6)
+
+    try:
+        with get_db_session() as session:
+            member_check = session.execute(
+                text("""
+                    SELECT 1
+                    FROM club_members cm
+                    JOIN clubs c ON c.club_id = cm.club_id
+                    WHERE cm.club_id = :club_id
+                      AND cm.user_id = :user_id
+                      AND cm.status = 'active'
+                      AND COALESCE(c.status, 'active') = 'active'
+                    LIMIT 1;
+                """),
+                {"club_id": club_id, "user_id": user},
+            ).fetchone()
+            if not member_check:
+                raise HTTPException(status_code=404, detail="Club not found")
+
+            members = [
+                dict(row)
+                for row in session.execute(
+                    text("""
+                        SELECT
+                            cm.user_id,
+                            u.first_name,
+                            u.username,
+                            u.avatar_path
+                        FROM club_members cm
+                        LEFT JOIN users u ON u.user_id = cm.user_id
+                        WHERE cm.club_id = :club_id
+                          AND cm.status = 'active'
+                        ORDER BY cm.joined_at_utc ASC;
+                    """),
+                    {"club_id": club_id},
+                ).mappings().fetchall()
+            ]
+
+            promises = [
+                dict(row)
+                for row in session.execute(
+                    text("""
+                        SELECT
+                            p.promise_uuid,
+                            p.text AS promise_text,
+                            CASE
+                                WHEN pi.metric_type = 'count' THEN 'count'
+                                ELSE 'hours'
+                            END AS metric_type,
+                            CASE
+                                WHEN pi.metric_type = 'count'
+                                    THEN COALESCE(pi.target_value, 7.0)
+                                ELSE COALESCE(pi.target_value, NULLIF(p.hours_per_week, 0), 1.0)
+                            END AS target_value
+                        FROM promise_club_shares pcs
+                        JOIN promises p
+                          ON p.promise_uuid = pcs.promise_uuid
+                         AND p.is_deleted = 0
+                        LEFT JOIN promise_instances pi
+                          ON pi.promise_uuid = p.promise_uuid
+                         AND pi.status = 'active'
+                        WHERE pcs.club_id = :club_id
+                        ORDER BY pcs.created_at_utc ASC;
+                    """),
+                    {"club_id": club_id},
+                ).mappings().fetchall()
+            ]
+
+            action_rows = session.execute(
+                text("""
+                    SELECT
+                        a.user_id,
+                        a.promise_uuid,
+                        a.action_type,
+                        COALESCE(a.time_spent_hours, 0.0) AS time_spent_hours,
+                        DATE(a.at_utc::timestamptz) AS action_date,
+                        a.at_utc AS at_utc
+                    FROM actions a
+                    JOIN club_members cm
+                      ON cm.user_id = a.user_id
+                     AND cm.club_id = :club_id
+                     AND cm.status = 'active'
+                    JOIN promise_club_shares pcs
+                      ON pcs.club_id = cm.club_id
+                     AND pcs.promise_uuid = a.promise_uuid
+                    WHERE DATE(a.at_utc::timestamptz) >= :window_start
+                      AND DATE(a.at_utc::timestamptz) <= :today
+                      AND a.action_type IN ('club_checkin', 'checkin', 'log_time');
+                """),
+                {"club_id": club_id, "window_start": window_start, "today": today},
+            ).mappings().fetchall()
+
+        actions_by_member_promise: dict[tuple[str, str], dict] = defaultdict(
+            lambda: {
+                "activity_days": set(),
+                "checkin_days": set(),
+                "duration_hours": 0.0,
+                "checkin_count": 0,
+                "last_activity_at_utc": None,
+            }
+        )
+        for row in action_rows:
+            key = (str(row["user_id"]), str(row["promise_uuid"]))
+            stats = actions_by_member_promise[key]
+            action_type = str(row["action_type"] or "")
+            if action_type in ("club_checkin", "checkin"):
+                action_date = _date_key(row["action_date"])
+                stats["activity_days"].add(action_date)
+                stats["checkin_days"].add(action_date)
+                stats["checkin_count"] += 1
+            elif action_type == "log_time":
+                hours = float(row["time_spent_hours"] or 0.0)
+                if hours > 0:
+                    stats["duration_hours"] += hours
+                    stats["activity_days"].add(_date_key(row["action_date"]))
+            at_utc = str(row["at_utc"]) if row["at_utc"] else None
+            if at_utc and (not stats["last_activity_at_utc"] or at_utc > stats["last_activity_at_utc"]):
+                stats["last_activity_at_utc"] = at_utc
+
+        all_members = _rank_club_leaderboard_members(
+            members=members,
+            promises=promises,
+            actions_by_member_promise=actions_by_member_promise,
+            today=today,
+            limit=max(len(members), limit),
+        )
+        selected_members = all_members[:limit]
+        average_score = (
+            round(sum(member.score_percent for member in all_members) / len(all_members), 1)
+            if all_members
+            else 0.0
+        )
+
+        return ClubLeaderboardResponse(
+            club_id=club_id,
+            window=window,
+            window_start=window_start.isoformat(),
+            window_end=today.isoformat(),
+            member_count=len(members),
+            promise_count=len(promises),
+            average_score_percent=average_score,
+            promises=[
+                ClubLeaderboardPromiseSummary(
+                    promise_uuid=str(promise["promise_uuid"]),
+                    promise_text=str(promise["promise_text"] or "Club promise"),
+                    metric_type=str(promise["metric_type"] or "hours"),
+                    target_value=float(promise["target_value"] or 1.0),
+                )
+                for promise in promises
+            ],
+            members=selected_members,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error loading club leaderboard for {club_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to load club leaderboard: {str(e)}")
 
 
 @router.post("/clubs", response_model=ClubSummary)

--- a/tm_bot/webapp/schemas.py
+++ b/tm_bot/webapp/schemas.py
@@ -152,6 +152,56 @@ class ClubMemberSummary(BaseModel):
     avatar_path: Optional[str] = None
 
 
+class ClubLeaderboardPromiseSummary(BaseModel):
+    """A promise included in the club leaderboard."""
+    promise_uuid: str
+    promise_text: str
+    metric_type: str = "hours"
+    target_value: float
+
+
+class ClubLeaderboardBreakdown(BaseModel):
+    """Per-promise contribution for one member's club leaderboard row."""
+    promise_uuid: str
+    promise_text: str
+    metric_type: str = "hours"
+    target_value: float
+    achieved_value: float
+    active_days: int = 0
+    duration_hours: float = 0.0
+    checkin_count: int = 0
+    progress_percent: float
+
+
+class ClubLeaderboardMember(BaseModel):
+    """Ranked member row for a mixed club leaderboard."""
+    rank: int
+    user_id: str
+    first_name: Optional[str] = None
+    username: Optional[str] = None
+    avatar_path: Optional[str] = None
+    score_percent: float
+    active_days: int = 0
+    duration_hours: float = 0.0
+    checkin_count: int = 0
+    freeze_streak: int = 0
+    last_activity_at_utc: Optional[str] = None
+    breakdown: List[ClubLeaderboardBreakdown] = Field(default_factory=list)
+
+
+class ClubLeaderboardResponse(BaseModel):
+    """Leaderboard for one club across all active shared promises."""
+    club_id: str
+    window: str
+    window_start: str
+    window_end: str
+    member_count: int = 0
+    promise_count: int = 0
+    average_score_percent: float = 0.0
+    promises: List[ClubLeaderboardPromiseSummary] = Field(default_factory=list)
+    members: List[ClubLeaderboardMember] = Field(default_factory=list)
+
+
 class ClubSummary(BaseModel):
     """Club summary for the Community page."""
     club_id: str
@@ -165,6 +215,7 @@ class ClubSummary(BaseModel):
     promise_id: Optional[str] = None
     promise_uuid: Optional[str] = None
     promise_text: Optional[str] = None
+    promise_count: Optional[int] = None
     target_count_per_week: Optional[float] = None
     reminder_time: Optional[str] = None
     language: Optional[str] = None

--- a/webapp_frontend/src/api/client.ts
+++ b/webapp_frontend/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   PublicUsersResponse,
   PublicActivityResponse,
   ClubSummary,
+  ClubLeaderboardResponse,
   ClubsResponse,
   ClubContextIngestResponse,
   CreateClubRequest,
@@ -40,7 +41,7 @@ import type {
   UpdatePdfHighlightRequest,
   FollowGraphData
 } from '../types';
-import { getMockClubs, getMockCommunityUsers, getMockPublicActivity, shouldUseLocalMockData } from './mockData';
+import { getMockClubLeaderboard, getMockClubs, getMockCommunityUsers, getMockPublicActivity, shouldUseLocalMockData } from './mockData';
 
 const API_BASE = '/api';
 
@@ -502,6 +503,13 @@ class ApiClient {
     return this.request<ClubsResponse>('/clubs');
   }
 
+  async getClubLeaderboard(clubId: string): Promise<ClubLeaderboardResponse> {
+    if (shouldUseLocalMockData()) {
+      return getMockClubLeaderboard(clubId);
+    }
+    return this.request<ClubLeaderboardResponse>(`/clubs/${clubId}/leaderboard?window=rolling_7d&limit=10`);
+  }
+
   /**
    * Create a minimal Xaana club with one shared promise.
    */
@@ -519,6 +527,7 @@ class ApiClient {
         promise_id: `promise-local-${now}`,
         promise_uuid: `promise-local-${now}`,
         promise_text: request.promise_text,
+        promise_count: 1,
         target_count_per_week: request.target_count_per_week,
         reminder_time: '21:00',
         language: 'en',

--- a/webapp_frontend/src/api/client.ts
+++ b/webapp_frontend/src/api/client.ts
@@ -40,6 +40,7 @@ import type {
   UpdatePdfHighlightRequest,
   FollowGraphData
 } from '../types';
+import { getMockClubs, getMockCommunityUsers, getMockPublicActivity, shouldUseLocalMockData } from './mockData';
 
 const API_BASE = '/api';
 
@@ -135,6 +136,36 @@ export interface AdminLLMBackendTestResponse {
 class ApiClient {
   public initData: string = '';  // Made public for TestsTab to access
   private authToken: string | null = null;
+  private mockClubs: ClubSummary[] | null = null;
+
+  private getLocalMockClubs(): ClubSummary[] {
+    if (!this.mockClubs) {
+      this.mockClubs = getMockClubs();
+    }
+    return this.mockClubs;
+  }
+
+  private updateLocalMockClub(
+    clubId: string,
+    patch: Partial<Record<keyof ClubSummary, ClubSummary[keyof ClubSummary] | null>>,
+  ): ClubSummary {
+    const clubs = this.getLocalMockClubs();
+    const index = clubs.findIndex((club) => club.club_id === clubId);
+    if (index === -1) {
+      throw new ApiError(404, 'Club not found');
+    }
+
+    const normalizedPatch = Object.fromEntries(
+      Object.entries(patch).map(([key, value]) => [key, value === null ? undefined : value]),
+    ) as Partial<ClubSummary>;
+    const updated = { ...clubs[index], ...normalizedPatch };
+    this.mockClubs = [
+      ...clubs.slice(0, index),
+      updated,
+      ...clubs.slice(index + 1),
+    ];
+    return updated;
+  }
 
   private buildAuthHeaders(existing: Record<string, string> = {}): Record<string, string> {
     const headers: Record<string, string> = { ...existing };
@@ -442,6 +473,10 @@ class ApiClient {
    * Get public list of users (authentication required).
    */
   async getPublicUsers(limit: number = 20): Promise<PublicUsersResponse> {
+    if (shouldUseLocalMockData()) {
+      const users = getMockCommunityUsers().slice(0, limit);
+      return { users, total: users.length };
+    }
     return this.request<PublicUsersResponse>(`/public/users?limit=${limit}`);
   }
 
@@ -449,6 +484,10 @@ class ApiClient {
    * Get recent public community activity.
    */
   async getPublicActivity(limit: number = 20): Promise<PublicActivityResponse> {
+    if (shouldUseLocalMockData()) {
+      const items = getMockPublicActivity().slice(0, limit);
+      return { items, total: items.length };
+    }
     return this.request<PublicActivityResponse>(`/public/activity?limit=${limit}`);
   }
 
@@ -456,6 +495,10 @@ class ApiClient {
    * Get clubs where the authenticated user is a member.
    */
   async getMyClubs(): Promise<ClubsResponse> {
+    if (shouldUseLocalMockData()) {
+      const clubs = this.getLocalMockClubs();
+      return { clubs, total: clubs.length };
+    }
     return this.request<ClubsResponse>('/clubs');
   }
 
@@ -463,6 +506,26 @@ class ApiClient {
    * Create a minimal Xaana club with one shared promise.
    */
   async createClub(request: CreateClubRequest): Promise<ClubSummary> {
+    if (shouldUseLocalMockData()) {
+      const now = Date.now();
+      const created: ClubSummary = {
+        club_id: `club-local-${now}`,
+        name: request.name,
+        visibility: request.visibility,
+        role: 'owner',
+        member_count: 1,
+        members: [{ user_id: 'local-dev-user', first_name: 'You', username: 'local_dev' }],
+        telegram_status: 'pending_admin_setup',
+        promise_id: `promise-local-${now}`,
+        promise_uuid: `promise-local-${now}`,
+        promise_text: request.promise_text,
+        target_count_per_week: request.target_count_per_week,
+        reminder_time: '21:00',
+        language: 'en',
+      };
+      this.mockClubs = [created, ...this.getLocalMockClubs()];
+      return created;
+    }
     return this.request<ClubSummary>('/clubs', {
       method: 'POST',
       body: JSON.stringify(request),
@@ -716,6 +779,10 @@ class ApiClient {
   }
 
   async removeMyClub(clubId: string): Promise<{ status: string; club_id: string; message: string }> {
+    if (shouldUseLocalMockData()) {
+      this.mockClubs = this.getLocalMockClubs().filter((club) => club.club_id !== clubId);
+      return { status: 'removed', club_id: clubId, message: 'Club removed from local mock data.' };
+    }
     return this.request<{ status: string; club_id: string; message: string }>(`/clubs/${clubId}`, {
       method: 'DELETE',
     });
@@ -725,6 +792,9 @@ class ApiClient {
     clubId: string,
     body: { reminder_time?: string; language?: string },
   ): Promise<ClubSummary> {
+    if (shouldUseLocalMockData()) {
+      return this.updateLocalMockClub(clubId, body);
+    }
     return this.request<ClubSummary>(`/clubs/${clubId}`, {
       method: 'PUT',
       body: JSON.stringify(body),
@@ -740,6 +810,9 @@ class ApiClient {
       checkin_what_counts?: string | null;
     },
   ): Promise<ClubSummary> {
+    if (shouldUseLocalMockData()) {
+      return this.updateLocalMockClub(clubId, body);
+    }
     return this.request<ClubSummary>(`/clubs/${clubId}/context`, {
       method: 'PUT',
       body: JSON.stringify(body),
@@ -750,6 +823,26 @@ class ApiClient {
     clubId: string,
     body: { notes: string; files?: File[] },
   ): Promise<ClubContextIngestResponse> {
+    if (shouldUseLocalMockData()) {
+      const club = await this.updateLocalMockClub(clubId, {
+        description: body.notes || 'Synthetic club context captured from local notes.',
+        club_goal: 'Turn shared intent into visible weekly progress.',
+        vibe: 'Encouraging and direct.',
+        checkin_what_counts: 'A check-in counts when the member reports concrete progress.',
+      });
+      return {
+        club,
+        extracted: {
+          description: club.description,
+          club_goal: club.club_goal,
+          vibe: club.vibe,
+          checkin_what_counts: club.checkin_what_counts,
+        },
+        follow_up_questions: ['Who should Xaana nudge first when the group gets quiet?'],
+        used_llm: false,
+        image_count: body.files?.length || 0,
+      };
+    }
     const form = new FormData();
     form.append('notes', body.notes || '');
     (body.files || []).forEach((file) => form.append('files', file));
@@ -778,6 +871,12 @@ class ApiClient {
     promiseUuid: string,
     body: { promise_text?: string; target_count_per_week?: number },
   ): Promise<ClubSummary> {
+    if (shouldUseLocalMockData()) {
+      return this.updateLocalMockClub(clubId, {
+        promise_text: body.promise_text,
+        target_count_per_week: body.target_count_per_week,
+      });
+    }
     return this.request<ClubSummary>(`/clubs/${clubId}/promises/${promiseUuid}`, {
       method: 'PUT',
       body: JSON.stringify(body),
@@ -788,6 +887,15 @@ class ApiClient {
     clubId: string,
     promiseUuid: string,
   ): Promise<{ status: string; club_id: string; message: string }> {
+    if (shouldUseLocalMockData()) {
+      await this.updateLocalMockClub(clubId, {
+        promise_id: undefined,
+        promise_uuid: undefined,
+        promise_text: undefined,
+        target_count_per_week: undefined,
+      });
+      return { status: 'deleted', club_id: clubId, message: 'Club promise deleted from local mock data.' };
+    }
     return this.request<{ status: string; club_id: string; message: string }>(
       `/clubs/${clubId}/promises/${promiseUuid}`,
       { method: 'DELETE' },
@@ -795,6 +903,9 @@ class ApiClient {
   }
 
   async syncClubDescription(clubId: string): Promise<{ status: string; club_id: string; message: string }> {
+    if (shouldUseLocalMockData()) {
+      return { status: 'updated', club_id: clubId, message: 'Local mock Telegram description synced.' };
+    }
     return this.request<{ status: string; club_id: string; message: string }>(
       `/clubs/${clubId}/sync-description`,
       { method: 'POST' },

--- a/webapp_frontend/src/api/mockData.ts
+++ b/webapp_frontend/src/api/mockData.ts
@@ -1,4 +1,4 @@
-import type { PublicUser, WeeklyReportData } from '../types';
+import type { ClubSummary, PublicActivityItem, PublicUser, WeeklyReportData } from '../types';
 
 function toLocalDateKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
@@ -127,6 +127,110 @@ export function getMockCommunityUsers(): PublicUser[] {
       weekly_activity_count: 3,
       promise_count: 3,
       last_activity_at_utc: new Date(Date.now() - 1000 * 60 * 140).toISOString(),
+    },
+  ];
+}
+
+export function getMockPublicActivity(): PublicActivityItem[] {
+  const users = getMockCommunityUsers();
+  const now = Date.now();
+  return [
+    {
+      activity_id: 'mock-activity-1',
+      action_type: 'club_checkin',
+      action_label: 'checked in for Morning Run Club',
+      duration_minutes: 32,
+      timestamp_utc: new Date(now - 1000 * 60 * 28).toISOString(),
+      promise_id: 'promise-morning-run',
+      promise_text: 'Run at least 3 km before work',
+      actor: users[0],
+    },
+    {
+      activity_id: 'mock-activity-2',
+      action_type: 'focus',
+      action_label: 'finished a deep work block',
+      duration_minutes: 90,
+      timestamp_utc: new Date(now - 1000 * 60 * 74).toISOString(),
+      promise_id: 'promise-deep-work',
+      promise_text: 'Complete one 90-minute focused work block',
+      actor: users[1],
+    },
+  ];
+}
+
+export function getMockClubs(): ClubSummary[] {
+  return [
+    {
+      club_id: 'club-morning-run',
+      name: 'Morning Run Club',
+      visibility: 'private',
+      role: 'owner',
+      member_count: 5,
+      members: [
+        { user_id: 'mock-101', first_name: 'Nora', username: 'nora_keeps_promises' },
+        { user_id: 'mock-102', first_name: 'Amir', username: 'amir_builds' },
+        { user_id: 'mock-103', first_name: 'Leila', username: 'leila_moves' },
+        { user_id: 'mock-104', first_name: 'Jon', username: 'jon_runs' },
+      ],
+      telegram_status: 'connected',
+      telegram_invite_link: 'https://t.me/example_morning_run_club',
+      promise_id: 'promise-morning-run',
+      promise_uuid: 'promise-morning-run',
+      promise_text: 'Run at least 3 km before work',
+      target_count_per_week: 4,
+      reminder_time: '07:15',
+      language: 'en',
+      description: 'A small accountability group for weekday morning runs.',
+      club_goal: 'Build a durable running habit without turning it into a race.',
+      vibe: 'Supportive, practical, low-drama.',
+      checkin_what_counts: 'A run, jog, or walk-run of 3 km or more counts.',
+    },
+    {
+      club_id: 'club-deep-work',
+      name: 'Deep Work Sprint',
+      visibility: 'public',
+      role: 'member',
+      member_count: 8,
+      members: [
+        { user_id: 'mock-105', first_name: 'Maya', username: 'maya_focus' },
+        { user_id: 'mock-106', first_name: 'Theo', username: 'theo_codes' },
+        { user_id: 'mock-107', first_name: 'Sara', username: 'sara_writes' },
+      ],
+      telegram_status: 'ready',
+      telegram_invite_link: 'https://t.me/example_deep_work_sprint',
+      promise_id: 'promise-deep-work',
+      promise_uuid: 'promise-deep-work',
+      promise_text: 'Complete one 90-minute focused work block',
+      target_count_per_week: 5,
+      reminder_time: '09:00',
+      language: 'en',
+      description: 'A weekday focus group for makers, students, and founders.',
+      club_goal: 'Make focused work visible and easier to repeat.',
+      vibe: 'Quiet, serious, kind.',
+      checkin_what_counts: 'A distraction-free 90-minute block with a clear outcome.',
+    },
+    {
+      club_id: 'club-language-table',
+      name: 'Language Table',
+      visibility: 'private',
+      role: 'owner',
+      member_count: 3,
+      members: [
+        { user_id: 'mock-108', first_name: 'Ana', username: 'ana_speaks' },
+        { user_id: 'mock-109', first_name: 'Rami', username: 'rami_words' },
+        { user_id: 'mock-110', first_name: 'Claire', username: 'claire_fr' },
+      ],
+      telegram_status: 'pending_admin_setup',
+      promise_id: 'promise-language-table',
+      promise_uuid: 'promise-language-table',
+      promise_text: 'Practice a target language for 20 minutes',
+      target_count_per_week: 3,
+      reminder_time: '20:30',
+      language: 'fr',
+      description: 'Friends practicing languages with lightweight check-ins.',
+      club_goal: 'Keep daily language practice social and forgiving.',
+      vibe: 'Casual and conversational.',
+      checkin_what_counts: 'Speaking, listening, reading, or writing practice for 20 minutes.',
     },
   ];
 }

--- a/webapp_frontend/src/api/mockData.ts
+++ b/webapp_frontend/src/api/mockData.ts
@@ -1,4 +1,4 @@
-import type { ClubSummary, PublicActivityItem, PublicUser, WeeklyReportData } from '../types';
+import type { ClubLeaderboardResponse, ClubSummary, PublicActivityItem, PublicUser, WeeklyReportData } from '../types';
 
 function toLocalDateKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
@@ -177,6 +177,7 @@ export function getMockClubs(): ClubSummary[] {
       promise_id: 'promise-morning-run',
       promise_uuid: 'promise-morning-run',
       promise_text: 'Run at least 3 km before work',
+      promise_count: 1,
       target_count_per_week: 4,
       reminder_time: '07:15',
       language: 'en',
@@ -201,6 +202,7 @@ export function getMockClubs(): ClubSummary[] {
       promise_id: 'promise-deep-work',
       promise_uuid: 'promise-deep-work',
       promise_text: 'Complete one 90-minute focused work block',
+      promise_count: 2,
       target_count_per_week: 5,
       reminder_time: '09:00',
       language: 'en',
@@ -224,6 +226,7 @@ export function getMockClubs(): ClubSummary[] {
       promise_id: 'promise-language-table',
       promise_uuid: 'promise-language-table',
       promise_text: 'Practice a target language for 20 minutes',
+      promise_count: 1,
       target_count_per_week: 3,
       reminder_time: '20:30',
       language: 'fr',
@@ -233,4 +236,95 @@ export function getMockClubs(): ClubSummary[] {
       checkin_what_counts: 'Speaking, listening, reading, or writing practice for 20 minutes.',
     },
   ];
+}
+
+export function getMockClubLeaderboard(clubId: string): ClubLeaderboardResponse {
+  const clubs = getMockClubs();
+  const club = clubs.find((item) => item.club_id === clubId) || clubs[0];
+  const today = new Date();
+  const windowEnd = toLocalDateKey(today);
+  const windowStartDate = new Date(today);
+  windowStartDate.setDate(today.getDate() - 6);
+  const windowStart = toLocalDateKey(windowStartDate);
+
+  const members = club.members.length > 0
+    ? club.members
+    : [{ user_id: 'local-dev-user', first_name: 'You', username: 'local_dev' }];
+  const promises = club.club_id === 'club-deep-work'
+    ? [
+        {
+          promise_uuid: 'promise-deep-work',
+          promise_text: 'Complete one 90-minute focused work block',
+          metric_type: 'count',
+          target_value: 5,
+        },
+        {
+          promise_uuid: 'promise-deep-work-hours',
+          promise_text: 'Log focused work hours',
+          metric_type: 'hours',
+          target_value: 6,
+        },
+      ]
+    : [
+        {
+          promise_uuid: club.promise_uuid || `${club.club_id}-promise`,
+          promise_text: club.promise_text || 'Club promise',
+          metric_type: 'count',
+          target_value: club.target_count_per_week || 7,
+        },
+      ];
+
+  const rows = members.slice(0, Math.min(Math.max(club.member_count, members.length), 10)).map((member, index) => {
+    const primaryTarget = promises[0].target_value;
+    const activeDays = Math.max(0, Math.min(primaryTarget, primaryTarget - index + (index === 0 ? 1 : 0)));
+    const breakdown = promises.map((promise, promiseIndex) => {
+      const achieved = promise.metric_type === 'count'
+        ? Math.max(0, activeDays - promiseIndex)
+        : Math.max(0, 4.5 - index * 0.75);
+      return {
+        promise_uuid: promise.promise_uuid,
+        promise_text: promise.promise_text,
+        metric_type: promise.metric_type,
+        target_value: promise.target_value,
+        achieved_value: achieved,
+        active_days: promise.metric_type === 'count' ? achieved : Math.min(7, Math.ceil(achieved)),
+        duration_hours: promise.metric_type === 'hours' ? achieved : 0,
+        checkin_count: promise.metric_type === 'count' ? achieved : 0,
+        progress_percent: Math.min(Math.round((achieved / promise.target_value) * 100), 100),
+      };
+    });
+    const score = Math.round(breakdown.reduce((sum, item) => sum + item.progress_percent, 0) / breakdown.length);
+    return {
+      rank: 0,
+      user_id: member.user_id,
+      first_name: member.first_name,
+      username: member.username,
+      avatar_path: member.avatar_path,
+      score_percent: score,
+      active_days: breakdown.reduce((sum, item) => sum + item.active_days, 0),
+      duration_hours: breakdown.reduce((sum, item) => sum + item.duration_hours, 0),
+      checkin_count: breakdown.reduce((sum, item) => sum + item.checkin_count, 0),
+      freeze_streak: Math.max(0, 9 - index * 2),
+      last_activity_at_utc: new Date(Date.now() - index * 1000 * 60 * 90).toISOString(),
+      breakdown,
+    };
+  });
+
+  const rankedRows = rows
+    .sort((left, right) => right.score_percent - left.score_percent || (right.last_activity_at_utc || '').localeCompare(left.last_activity_at_utc || ''))
+    .map((row, index) => ({ ...row, rank: index + 1 }));
+
+  return {
+    club_id: club.club_id,
+    window: 'rolling_7d',
+    window_start: windowStart,
+    window_end: windowEnd,
+    member_count: club.member_count,
+    promise_count: promises.length,
+    average_score_percent: rankedRows.length
+      ? Math.round(rankedRows.reduce((sum, row) => sum + row.score_percent, 0) / rankedRows.length)
+      : 0,
+    promises,
+    members: rankedRows,
+  };
 }

--- a/webapp_frontend/src/components/UsersPage.tsx
+++ b/webapp_frontend/src/components/UsersPage.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiClient, ApiError } from '../api/client';
+import { shouldUseLocalMockData } from '../api/mockData';
 import { ActivityItem } from './community/ActivityItem';
 import { CompactUserChip } from './community/CompactUserChip';
-import { AvatarStack } from './ui/AvatarStack';
+import { ClubBadge } from './clubs/ClubBadge';
 import type { ClubSummary, PublicActivityItem, PublicUser, UserInfo } from '../types';
 import { getDevInitData, useTelegramWebApp } from '../hooks/useTelegramWebApp';
 
@@ -115,7 +116,8 @@ export function UsersPage() {
 
   const authData = initData || getDevInitData();
   const hasToken = !!localStorage.getItem('telegram_auth_token');
-  const isAuthenticated = !!authData || hasToken;
+  const allowLocalMockData = shouldUseLocalMockData();
+  const isAuthenticated = !!authData || hasToken || allowLocalMockData;
 
   useEffect(() => {
     if (authData) {
@@ -304,12 +306,6 @@ export function UsersPage() {
     }
   }, []);
 
-  const handleClubCardKeyDown = useCallback((event: KeyboardEvent<HTMLElement>, club: ClubSummary) => {
-    if (event.key !== 'Enter' && event.key !== ' ') return;
-    event.preventDefault();
-    navigate(`/clubs/${club.club_id}`);
-  }, [navigate]);
-
   if (!isReady) {
     return (
       <div className="users-page">
@@ -379,58 +375,13 @@ export function UsersPage() {
             ) : clubs.length > 0 ? (
               <div className="community-club-grid">
                 {clubs.map((club) => (
-                  <article
-                    className="community-club-card community-club-card-clickable"
+                  <ClubBadge
                     key={club.club_id}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`Open ${club.name} club details`}
-                    onClick={() => navigate(`/clubs/${club.club_id}`)}
-                    onKeyDown={(event) => handleClubCardKeyDown(event, club)}
-                  >
-                    <div className="community-club-card-header">
-                      <h4>{club.name}</h4>
-                      <span>{club.visibility}</span>
-                    </div>
-                    <p>{club.promise_text || 'No shared promise yet'}</p>
-                    <div className="community-club-meta">
-                      <span className="community-club-members">
-                        <AvatarStack users={club.members} size={24} max={4} />
-                        {club.member_count} {club.member_count === 1 ? 'member' : 'members'}
-                      </span>
-                      {club.target_count_per_week ? <span>{club.target_count_per_week}x/week</span> : null}
-                      {club.telegram_invite_link && ['ready', 'connected'].includes(club.telegram_status) ? (
-                        <a
-                          className="community-club-telegram-link"
-                          href={club.telegram_invite_link}
-                          target="_blank"
-                          rel="noreferrer"
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          Join Telegram
-                        </a>
-                      ) : (
-                        <span>Telegram pending</span>
-                      )}
-                    </div>
-                    {club.role === 'owner' && club.telegram_status !== 'pending_admin_setup' ? null : (
-                      <button
-                        type="button"
-                        className="community-club-remove"
-                        disabled={!!clubBusyById[club.club_id]}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          handleRemoveClub(club);
-                        }}
-                      >
-                        {clubBusyById[club.club_id]
-                          ? 'Updating...'
-                          : club.role === 'owner'
-                            ? 'Cancel club'
-                            : 'Leave club'}
-                      </button>
-                    )}
-                  </article>
+                    club={club}
+                    busy={!!clubBusyById[club.club_id]}
+                    onOpenSettings={(item) => navigate(`/clubs/${item.club_id}`)}
+                    onRemove={handleRemoveClub}
+                  />
                 ))}
               </div>
             ) : (

--- a/webapp_frontend/src/components/clubs/ClubBadge.tsx
+++ b/webapp_frontend/src/components/clubs/ClubBadge.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useState, type KeyboardEvent } from 'react';
+import { ExternalLink, Settings, Shield, Trophy, Users } from 'lucide-react';
+import type { ClubSummary } from '../../types';
+import { Badge } from '../ui/Badge';
+import { BottomSheet } from '../ui/BottomSheet';
+import { Button } from '../ui/Button';
+import { AvatarStack } from '../ui/AvatarStack';
+
+interface ClubBadgeProps {
+  club: ClubSummary;
+  busy?: boolean;
+  onOpenSettings: (club: ClubSummary) => void;
+  onRemove: (club: ClubSummary) => void;
+}
+
+type LeaderboardMember = ClubSummary['members'][number] & {
+  checkins: number;
+  target: number;
+  progress: number;
+  streak: number;
+};
+
+function seedFromText(value: string): number {
+  return Array.from(value).reduce((acc, char) => acc + char.charCodeAt(0), 0);
+}
+
+function getLeaderboard(club: ClubSummary): LeaderboardMember[] {
+  const target = Math.max(1, club.target_count_per_week || 1);
+  const fallbackNames = ['Sam', 'Iris', 'Noah', 'Mina', 'Leo', 'Yara', 'Owen', 'Zoe', 'Kai', 'Nina'];
+  const members = [...club.members];
+  const desiredCount = Math.min(Math.max(club.member_count, members.length, 1), 10);
+  while (members.length < desiredCount) {
+    const index = members.length;
+    members.push({
+      user_id: `${club.club_id}-member-${index + 1}`,
+      first_name: fallbackNames[index % fallbackNames.length],
+    });
+  }
+
+  return members
+    .slice(0, desiredCount)
+    .map((member, index) => {
+      const seed = seedFromText(`${club.club_id}-${member.user_id}-${index}`);
+      const checkins = Math.min(target, Math.max(0, target - (seed % Math.min(target + 1, 4))));
+      return {
+        ...member,
+        checkins,
+        target,
+        progress: Math.round((checkins / target) * 100),
+        streak: 1 + (seed % 6),
+      };
+    })
+    .sort((left, right) => right.progress - left.progress || right.streak - left.streak);
+}
+
+function getStatus(progress: number): { label: string; variant: 'good' | 'warn' | 'bad' } {
+  if (progress >= 70) return { label: 'On track', variant: 'good' };
+  if (progress >= 40) return { label: 'Building', variant: 'warn' };
+  return { label: 'Needs push', variant: 'bad' };
+}
+
+export function ClubBadge({ club, busy = false, onOpenSettings, onRemove }: ClubBadgeProps) {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [leaderboardLimit, setLeaderboardLimit] = useState(5);
+  const leaderboard = useMemo(() => getLeaderboard(club), [club]);
+  const shownLeaderboard = leaderboard.slice(0, leaderboardLimit);
+  const target = Math.max(1, club.target_count_per_week || 1);
+  const avgCheckins = leaderboard.length
+    ? leaderboard.reduce((sum, member) => sum + member.checkins, 0) / leaderboard.length
+    : 0;
+  const progress = Math.min(Math.round((avgCheckins / target) * 100), 100);
+  const status = getStatus(progress);
+  const topMember = leaderboard[0];
+  const telegramReady = !!club.telegram_invite_link && ['ready', 'connected'].includes(club.telegram_status);
+
+  const openSheet = () => setSheetOpen(true);
+  const closeSheet = () => setSheetOpen(false);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    openSheet();
+  };
+
+  return (
+    <>
+      <article
+        className={`pcard club-badge-card ${status.variant}`}
+        role="button"
+        tabIndex={0}
+        aria-label={`Open ${club.name} club`}
+        onClick={openSheet}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="top">
+          <div className="title">
+            <span dir="auto">{club.name}</span>
+            <span className="pid" dir="ltr">#{club.visibility}</span>
+          </div>
+          <Badge variant={status.variant} showDot>{status.label}</Badge>
+        </div>
+
+        <p className="club-badge-promise">{club.promise_text || 'No shared promise yet'}</p>
+
+        <div className="club-badge-member-strip">
+          <AvatarStack users={club.members} size={24} max={5} />
+          <span>{club.member_count} {club.member_count === 1 ? 'member' : 'members'}</span>
+          {topMember ? <span>Lead: {topMember.first_name || topMember.username || 'Member'}</span> : null}
+        </div>
+
+        <div className="progress" aria-hidden="true">
+          <div className="fill" style={{ width: `${progress}%` }} />
+        </div>
+
+        <div className="row">
+          <span className="sub" dir="ltr">{avgCheckins.toFixed(1)}/{target} avg check-ins</span>
+          <span className="meta" dir="ltr">{progress}%</span>
+        </div>
+      </article>
+
+      <BottomSheet
+        open={sheetOpen}
+        onClose={closeSheet}
+        title={club.name}
+        subtitle={club.promise_text || 'Club promise'}
+        headerActions={(
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm sheet-icon-action"
+            onClick={() => onOpenSettings(club)}
+            aria-label="Open club settings"
+          >
+            <Settings size={18} aria-hidden />
+          </button>
+        )}
+      >
+        <section className="overall club-sheet-overall">
+          <div className="row">
+            <span className="label">Club progress</span>
+            <span className="sub">{club.member_count} members</span>
+          </div>
+          <div className="row" style={{ marginTop: 2 }}>
+            <span className="value">{progress}%</span>
+            <Badge variant={status.variant} showDot>{status.label}</Badge>
+          </div>
+          <div className="track" style={{ marginTop: 10 }}>
+            <div className="fill" style={{ width: `${progress}%` }} />
+          </div>
+          <div className="club-sheet-stats">
+            <span><Users size={14} aria-hidden /> {club.member_count}</span>
+            <span><Trophy size={14} aria-hidden /> {avgCheckins.toFixed(1)}/{target} avg</span>
+            <span><Shield size={14} aria-hidden /> {club.role}</span>
+          </div>
+        </section>
+
+        <div className="club-sheet-section-head">
+          <p className="ds-eyebrow">Leaderboard</p>
+          <div className="club-sheet-limit" aria-label="Leaderboard size">
+            {[3, 5, 10].map((limit) => (
+              <button
+                type="button"
+                key={limit}
+                className={leaderboardLimit === limit ? 'is-active' : ''}
+                onClick={() => setLeaderboardLimit(limit)}
+              >
+                Top {limit}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="club-leaderboard">
+          {shownLeaderboard.map((member, index) => (
+            <div className="club-leaderboard-row" key={member.user_id}>
+              <span className="club-leaderboard-rank">{index + 1}</span>
+              <div className="club-leaderboard-person">
+                <strong>{member.first_name || member.username || 'Member'}</strong>
+                <span>{member.streak} day streak</span>
+              </div>
+              <div className="club-leaderboard-progress">
+                <span>{member.checkins}/{member.target}</span>
+                <div className="club-leaderboard-track" aria-hidden="true">
+                  <div style={{ width: `${member.progress}%` }} />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="action-row club-sheet-actions">
+          {telegramReady ? (
+            <Button
+              variant="secondary"
+              onClick={() => window.open(club.telegram_invite_link, '_blank', 'noopener,noreferrer')}
+            >
+              <ExternalLink size={14} />
+              Telegram
+            </Button>
+          ) : (
+            <Button variant="secondary" disabled>
+              <ExternalLink size={14} />
+              Pending
+            </Button>
+          )}
+          <Button variant="secondary" onClick={() => onOpenSettings(club)}>
+            <Settings size={14} />
+            Manage
+          </Button>
+          <Button
+            variant="danger"
+            disabled={busy}
+            onClick={() => {
+              closeSheet();
+              onRemove(club);
+            }}
+          >
+            {club.role === 'owner' ? 'Cancel' : 'Leave'}
+          </Button>
+        </div>
+      </BottomSheet>
+    </>
+  );
+}

--- a/webapp_frontend/src/components/clubs/ClubBadge.tsx
+++ b/webapp_frontend/src/components/clubs/ClubBadge.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState, type KeyboardEvent } from 'react';
+import { useEffect, useState, type KeyboardEvent } from 'react';
 import { ExternalLink, Settings, Shield, Trophy, Users } from 'lucide-react';
-import type { ClubSummary } from '../../types';
+import { apiClient } from '../../api/client';
+import type { ClubLeaderboardMember, ClubLeaderboardResponse, ClubSummary } from '../../types';
 import { Badge } from '../ui/Badge';
 import { BottomSheet } from '../ui/BottomSheet';
 import { Button } from '../ui/Button';
@@ -13,68 +14,62 @@ interface ClubBadgeProps {
   onRemove: (club: ClubSummary) => void;
 }
 
-type LeaderboardMember = ClubSummary['members'][number] & {
-  checkins: number;
-  target: number;
-  progress: number;
-  streak: number;
-};
-
-function seedFromText(value: string): number {
-  return Array.from(value).reduce((acc, char) => acc + char.charCodeAt(0), 0);
-}
-
-function getLeaderboard(club: ClubSummary): LeaderboardMember[] {
-  const target = Math.max(1, club.target_count_per_week || 1);
-  const fallbackNames = ['Sam', 'Iris', 'Noah', 'Mina', 'Leo', 'Yara', 'Owen', 'Zoe', 'Kai', 'Nina'];
-  const members = [...club.members];
-  const desiredCount = Math.min(Math.max(club.member_count, members.length, 1), 10);
-  while (members.length < desiredCount) {
-    const index = members.length;
-    members.push({
-      user_id: `${club.club_id}-member-${index + 1}`,
-      first_name: fallbackNames[index % fallbackNames.length],
-    });
-  }
-
-  return members
-    .slice(0, desiredCount)
-    .map((member, index) => {
-      const seed = seedFromText(`${club.club_id}-${member.user_id}-${index}`);
-      const checkins = Math.min(target, Math.max(0, target - (seed % Math.min(target + 1, 4))));
-      return {
-        ...member,
-        checkins,
-        target,
-        progress: Math.round((checkins / target) * 100),
-        streak: 1 + (seed % 6),
-      };
-    })
-    .sort((left, right) => right.progress - left.progress || right.streak - left.streak);
-}
-
 function getStatus(progress: number): { label: string; variant: 'good' | 'warn' | 'bad' } {
   if (progress >= 70) return { label: 'On track', variant: 'good' };
   if (progress >= 40) return { label: 'Building', variant: 'warn' };
   return { label: 'Needs push', variant: 'bad' };
 }
 
+function formatValue(value: number, metricType: string): string {
+  if (metricType === 'hours') {
+    return `${value.toFixed(value % 1 === 0 ? 0 : 1)}h`;
+  }
+  return String(Math.round(value));
+}
+
+function formatBreakdown(member: ClubLeaderboardMember): string {
+  if (!member.breakdown.length) return 'No activity yet';
+  return member.breakdown
+    .slice(0, 3)
+    .map((item) => `${item.promise_text}: ${formatValue(item.achieved_value, item.metric_type)}/${formatValue(item.target_value, item.metric_type)}`)
+    .join(' | ');
+}
+
 export function ClubBadge({ club, busy = false, onOpenSettings, onRemove }: ClubBadgeProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
-  const [leaderboardLimit, setLeaderboardLimit] = useState(5);
-  const leaderboard = useMemo(() => getLeaderboard(club), [club]);
-  const shownLeaderboard = leaderboard.slice(0, leaderboardLimit);
-  const target = Math.max(1, club.target_count_per_week || 1);
-  const avgCheckins = leaderboard.length
-    ? leaderboard.reduce((sum, member) => sum + member.checkins, 0) / leaderboard.length
-    : 0;
-  const progress = Math.min(Math.round((avgCheckins / target) * 100), 100);
+  const [leaderboard, setLeaderboard] = useState<ClubLeaderboardResponse | null>(null);
+  const [leaderboardLoading, setLeaderboardLoading] = useState(false);
+  const [leaderboardError, setLeaderboardError] = useState('');
+  const progress = leaderboard?.average_score_percent ?? 0;
   const status = getStatus(progress);
-  const topMember = leaderboard[0];
+  const topMember = leaderboard?.members[0];
   const telegramReady = !!club.telegram_invite_link && ['ready', 'connected'].includes(club.telegram_status);
 
   const openSheet = () => setSheetOpen(true);
   const closeSheet = () => setSheetOpen(false);
+
+  useEffect(() => {
+    if (!sheetOpen || leaderboard) return;
+    let cancelled = false;
+    setLeaderboardLoading(true);
+    setLeaderboardError('');
+    apiClient.getClubLeaderboard(club.club_id)
+      .then((data) => {
+        if (!cancelled) setLeaderboard(data);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error('Failed to load club leaderboard:', err);
+          setLeaderboardError(err instanceof Error ? err.message : 'Failed to load leaderboard.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLeaderboardLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [club.club_id, leaderboard, sheetOpen]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
     if (event.key !== 'Enter' && event.key !== ' ') return;
@@ -85,7 +80,7 @@ export function ClubBadge({ club, busy = false, onOpenSettings, onRemove }: Club
   return (
     <>
       <article
-        className={`pcard club-badge-card ${status.variant}`}
+        className={['pcard', 'club-badge-card', leaderboard ? status.variant : ''].filter(Boolean).join(' ')}
         role="button"
         tabIndex={0}
         aria-label={`Open ${club.name} club`}
@@ -97,7 +92,9 @@ export function ClubBadge({ club, busy = false, onOpenSettings, onRemove }: Club
             <span dir="auto">{club.name}</span>
             <span className="pid" dir="ltr">#{club.visibility}</span>
           </div>
-          <Badge variant={status.variant} showDot>{status.label}</Badge>
+          <Badge variant={leaderboard ? status.variant : 'neutral'} showDot={!!leaderboard}>
+            {leaderboard ? status.label : 'Club'}
+          </Badge>
         </div>
 
         <p className="club-badge-promise">{club.promise_text || 'No shared promise yet'}</p>
@@ -105,16 +102,19 @@ export function ClubBadge({ club, busy = false, onOpenSettings, onRemove }: Club
         <div className="club-badge-member-strip">
           <AvatarStack users={club.members} size={24} max={5} />
           <span>{club.member_count} {club.member_count === 1 ? 'member' : 'members'}</span>
+          <span>{club.promise_count || (club.promise_uuid ? 1 : 0)} {(club.promise_count || 0) === 1 ? 'promise' : 'promises'}</span>
           {topMember ? <span>Lead: {topMember.first_name || topMember.username || 'Member'}</span> : null}
         </div>
 
-        <div className="progress" aria-hidden="true">
-          <div className="fill" style={{ width: `${progress}%` }} />
-        </div>
+        {leaderboard ? (
+          <div className="progress" aria-hidden="true">
+            <div className="fill" style={{ width: `${progress}%` }} />
+          </div>
+        ) : null}
 
         <div className="row">
-          <span className="sub" dir="ltr">{avgCheckins.toFixed(1)}/{target} avg check-ins</span>
-          <span className="meta" dir="ltr">{progress}%</span>
+          <span className="sub" dir="ltr">{leaderboard ? `${leaderboard.window_start} - ${leaderboard.window_end}` : 'Open leaderboard'}</span>
+          <span className="meta" dir="ltr">{leaderboard ? `${progress}%` : 'Rolling 7d'}</span>
         </div>
       </article>
 
@@ -137,7 +137,7 @@ export function ClubBadge({ club, busy = false, onOpenSettings, onRemove }: Club
         <section className="overall club-sheet-overall">
           <div className="row">
             <span className="label">Club progress</span>
-            <span className="sub">{club.member_count} members</span>
+            <span className="sub">{leaderboard?.member_count ?? club.member_count} members</span>
           </div>
           <div className="row" style={{ marginTop: 2 }}>
             <span className="value">{progress}%</span>
@@ -147,44 +147,39 @@ export function ClubBadge({ club, busy = false, onOpenSettings, onRemove }: Club
             <div className="fill" style={{ width: `${progress}%` }} />
           </div>
           <div className="club-sheet-stats">
-            <span><Users size={14} aria-hidden /> {club.member_count}</span>
-            <span><Trophy size={14} aria-hidden /> {avgCheckins.toFixed(1)}/{target} avg</span>
+            <span><Users size={14} aria-hidden /> {leaderboard?.member_count ?? club.member_count}</span>
+            <span><Trophy size={14} aria-hidden /> {leaderboard ? `${leaderboard.average_score_percent}% avg` : 'Loading'}</span>
             <span><Shield size={14} aria-hidden /> {club.role}</span>
           </div>
         </section>
 
         <div className="club-sheet-section-head">
           <p className="ds-eyebrow">Leaderboard</p>
-          <div className="club-sheet-limit" aria-label="Leaderboard size">
-            {[3, 5, 10].map((limit) => (
-              <button
-                type="button"
-                key={limit}
-                className={leaderboardLimit === limit ? 'is-active' : ''}
-                onClick={() => setLeaderboardLimit(limit)}
-              >
-                Top {limit}
-              </button>
-            ))}
-          </div>
+          {leaderboard ? <span className="club-sheet-window">{leaderboard.window_start} - {leaderboard.window_end}</span> : null}
         </div>
 
         <div className="club-leaderboard">
-          {shownLeaderboard.map((member, index) => (
+          {leaderboardLoading ? (
+            <div className="club-leaderboard-state">Loading leaderboard...</div>
+          ) : leaderboardError ? (
+            <div className="club-leaderboard-state club-leaderboard-state--error">{leaderboardError}</div>
+          ) : leaderboard && leaderboard.members.length === 0 ? (
+            <div className="club-leaderboard-state">No leaderboard activity yet.</div>
+          ) : leaderboard?.members.map((member) => (
             <div className="club-leaderboard-row" key={member.user_id}>
-              <span className="club-leaderboard-rank">{index + 1}</span>
+              <span className="club-leaderboard-rank">{member.rank}</span>
               <div className="club-leaderboard-person">
                 <strong>{member.first_name || member.username || 'Member'}</strong>
-                <span>{member.streak} day streak</span>
+                <span>{member.freeze_streak} day streak | {formatBreakdown(member)}</span>
               </div>
               <div className="club-leaderboard-progress">
-                <span>{member.checkins}/{member.target}</span>
+                <span>{member.score_percent}%</span>
                 <div className="club-leaderboard-track" aria-hidden="true">
-                  <div style={{ width: `${member.progress}%` }} />
+                  <div style={{ width: `${member.score_percent}%` }} />
                 </div>
               </div>
             </div>
-          ))}
+          )) || null}
         </div>
 
         <div className="action-row club-sheet-actions">

--- a/webapp_frontend/src/styles/sheets.css
+++ b/webapp_frontend/src/styles/sheets.css
@@ -290,6 +290,188 @@
 .pcard .row { display: flex; justify-content: space-between; align-items: center; }
 .pcard .row .sub { font-size: 11px; color: var(--fg-subtle); }
 
+.club-badge-card {
+  min-width: 0;
+}
+
+.club-badge-card .fill {
+  background: linear-gradient(90deg, var(--good-500), var(--accent));
+}
+
+.club-badge-promise {
+  margin: 0;
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.club-badge-member-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.club-badge-member-strip > span {
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: rgba(230, 234, 245, 0.04);
+  padding: 0 8px;
+}
+
+.club-sheet-overall .fill {
+  background: linear-gradient(90deg, var(--good-500), var(--accent));
+}
+
+.club-sheet-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.club-sheet-stats span {
+  min-width: 0;
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-8);
+  background: rgba(230, 234, 245, 0.04);
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  text-transform: capitalize;
+}
+
+.club-sheet-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.club-sheet-section-head .ds-eyebrow {
+  margin: 0;
+}
+
+.club-sheet-limit {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: rgba(230, 234, 245, 0.04);
+}
+
+.club-sheet-limit button {
+  height: 26px;
+  border: 0;
+  border-radius: var(--r-pill);
+  padding: 0 9px;
+  background: transparent;
+  color: var(--fg-muted);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.club-sheet-limit button.is-active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.club-leaderboard {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.club-leaderboard-row {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) minmax(92px, 124px);
+  align-items: center;
+  gap: 10px;
+  min-height: 52px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-8);
+  background: var(--surface);
+}
+
+.club-leaderboard-rank {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-pill);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+}
+
+.club-leaderboard-person {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.club-leaderboard-person strong {
+  min-width: 0;
+  color: var(--fg);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.club-leaderboard-person span {
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.club-leaderboard-progress {
+  display: grid;
+  gap: 5px;
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 800;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.club-leaderboard-track {
+  height: 4px;
+  border-radius: var(--r-pill);
+  overflow: hidden;
+  background: rgba(230, 234, 245, 0.08);
+}
+
+.club-leaderboard-track div {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--good-500);
+}
+
+.club-sheet-actions {
+  margin-top: 16px;
+}
+
 .list { display: grid; gap: 10px; }
 
 .field-row { display: grid; gap: 6px; }

--- a/webapp_frontend/src/styles/sheets.css
+++ b/webapp_frontend/src/styles/sheets.css
@@ -366,37 +366,37 @@
   margin: 0;
 }
 
-.club-sheet-limit {
-  display: inline-flex;
-  gap: 4px;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-pill);
-  background: rgba(230, 234, 245, 0.04);
-}
-
-.club-sheet-limit button {
-  height: 26px;
-  border: 0;
-  border-radius: var(--r-pill);
-  padding: 0 9px;
-  background: transparent;
-  color: var(--fg-muted);
-  font: inherit;
+.club-sheet-window {
+  color: var(--fg-subtle);
   font-size: 11px;
   font-weight: 800;
-  cursor: pointer;
-}
-
-.club-sheet-limit button.is-active {
-  background: var(--accent-soft);
-  color: var(--accent);
+  font-family: var(--font-mono);
+  white-space: nowrap;
 }
 
 .club-leaderboard {
   display: grid;
   gap: 8px;
   margin-top: 10px;
+}
+
+.club-leaderboard-state {
+  min-height: 56px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-8);
+  background: var(--surface);
+  color: var(--fg-muted);
+  font-size: 13px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.club-leaderboard-state--error {
+  color: var(--bad-500);
+  border-color: rgba(248, 113, 113, 0.32);
+  background: rgba(248, 113, 113, 0.08);
 }
 
 .club-leaderboard-row {

--- a/webapp_frontend/src/types.ts
+++ b/webapp_frontend/src/types.ts
@@ -204,6 +204,7 @@ export interface ClubSummary {
   promise_id?: string;
   promise_uuid?: string;
   promise_text?: string;
+  promise_count?: number;
   target_count_per_week?: number;
   reminder_time?: string;
   language?: string;
@@ -211,6 +212,52 @@ export interface ClubSummary {
   club_goal?: string;
   vibe?: string;
   checkin_what_counts?: string;
+}
+
+export interface ClubLeaderboardPromiseSummary {
+  promise_uuid: string;
+  promise_text: string;
+  metric_type: string;
+  target_value: number;
+}
+
+export interface ClubLeaderboardBreakdown {
+  promise_uuid: string;
+  promise_text: string;
+  metric_type: string;
+  target_value: number;
+  achieved_value: number;
+  active_days: number;
+  duration_hours: number;
+  checkin_count: number;
+  progress_percent: number;
+}
+
+export interface ClubLeaderboardMember {
+  rank: number;
+  user_id: string;
+  first_name?: string;
+  username?: string;
+  avatar_path?: string;
+  score_percent: number;
+  active_days: number;
+  duration_hours: number;
+  checkin_count: number;
+  freeze_streak: number;
+  last_activity_at_utc?: string;
+  breakdown: ClubLeaderboardBreakdown[];
+}
+
+export interface ClubLeaderboardResponse {
+  club_id: string;
+  window: string;
+  window_start: string;
+  window_end: string;
+  member_count: number;
+  promise_count: number;
+  average_score_percent: number;
+  promises: ClubLeaderboardPromiseSummary[];
+  members: ClubLeaderboardMember[];
 }
 
 export interface ClubsResponse {


### PR DESCRIPTION
## Summary
- Add a backend-calculated club leaderboard endpoint over a rolling 7-day UTC window.
- Score one mixed leaderboard per club across all shared active promises, normalizing count and duration promises before averaging.
- Replace the synthetic club sheet leaderboard with fetched backend data, including loading/error/empty states and local dev mock payloads.
- Keep club listing backward compatible while exposing `promise_count`.

## Validation
- `python -m pytest tests/webapp/test_club_leaderboard.py`
- `npm run build`

## Notes
- Ranking now sorts by score, latest activity, freeze-aware streak, then display name.
- Binary/count promises count distinct check-in days only; duration/log promises score by logged hours.
