### PR TITLE
fix: store one-off reminders as one-time, not recurring (#63)

### DIFF
--- a/tests/nonfunctional/test_safety_regression.py
+++ b/tests/nonfunctional/test_safety_regression.py
@@ -62,6 +62,28 @@ def test_add_promise_negative_hours_rejected(tmp_path):
 
 @pytest.mark.nonfunctional
 @pytest.mark.requires_postgres
+def test_create_reminder_is_one_time_not_recurring(tmp_path):
+    """Regression for #63: a one-off reminder must not be stored as a recurring promise.
+
+    The LLM correctly routes "remind me ... tonight" to create_reminder, but the
+    adapter previously persisted it with recurring=True, surfacing it as a weekly
+    promise. It must be a one-time ('T'-prefixed) promise instead.
+    """
+    user_id = unique_user_id()
+    ensure_users_exist(user_id)
+    adapter = PlannerAPIAdapter(str(tmp_path))
+
+    adapter.create_reminder(user_id, text="make BBQ", remind_at="2026-05-30T20:00:00")
+
+    promises = adapter.get_promises(user_id)
+    assert len(promises) == 1
+    p = promises[0]
+    assert bool(p.get("recurring")) is False, "reminder must not be recurring"
+    assert str(p["id"]).startswith("T"), "reminder must be a one-time (T) promise"
+
+
+@pytest.mark.nonfunctional
+@pytest.mark.requires_postgres
 def test_add_action_negative_time_returns_error_no_write(tmp_path):
     """Adapter returns error for negative time_spent and does not append action."""
     user_id = unique_user_id()

--- a/tm_bot/services/planner_api_adapter.py
+++ b/tm_bot/services/planner_api_adapter.py
@@ -225,7 +225,7 @@ class PlannerAPIAdapter:
                 user_id=user_id,
                 promise_text=text,
                 num_hours_promised_per_week=0.0,
-                recurring=True,
+                recurring=False,
                 end_date=remind_dt.date(),
             )
         except Exception as e:


### PR DESCRIPTION
## Problem
Issue #63: "set a reminder for make BBQ tonight" wrongly created a **recurring weekly promise**.

## Root cause
The LLM routes the request correctly to the one-off `create_reminder` tool, but the adapter persisted it via `add_promise(recurring=True)` (`planner_api_adapter.py`), so it became a weekly recurring promise with a `P` permanent id instead of a one-time `T` promise. This also contradicted `create_reminder`'s own docstring ("backed by a one-time promise").

## Fix
- Flip `recurring=False` in `create_reminder`. Reminders are now stored as one-time `T`-prefixed promises.
- Add a `requires_postgres` regression test asserting a reminder is non-recurring and `T`-prefixed.

The transparency half of #63 (confirmation preview distinguishing "one-off reminder, not a weekly promise") already shipped earlier, so this completes the issue.

## Validation
Could not run locally (env lacks `pandas`; adapter tests are `requires_postgres`-gated). Will validate on staging / CI. The change is a single boolean matching the documented contract.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
