### PR TITLE
feat(content): create a watch/read session when content is assigned to a promise (#54)

### DIFF
--- a/tests/repositories/test_content_repo.py
+++ b/tests/repositories/test_content_repo.py
@@ -4,8 +4,11 @@ import uuid
 import pytest
 from sqlalchemy import text
 
-from db.postgres_db import get_db_session
+from db.postgres_db import get_db_session, resolve_promise_uuid
+from models.models import Promise
 from repositories.content_repo import ContentRepository
+from repositories.plan_sessions_repo import PlanSessionsRepository
+from repositories.promises_repo import PromisesRepository
 
 pytestmark = [pytest.mark.repo, pytest.mark.requires_postgres]
 
@@ -38,6 +41,59 @@ def test_user_content_roundtrip():
     assert uc2 is not None
     assert uc2.get("notes") == "My note"
     assert uc2.get("rating") == 5
+
+
+def test_assign_content_to_promise_creates_deduped_watch_session():
+    """#54: assigning content to a promise creates one watch/read session, deduped on re-assign."""
+    repo = ContentRepository()
+    user_id = "test-assign-" + uuid.uuid4().hex[:8]
+    suffix = uuid.uuid4().hex[:8]
+
+    promises_repo = PromisesRepository()
+    promises_repo.upsert_promise(
+        user_id=user_id,
+        promise=Promise(
+            user_id=user_id,
+            id="T54",
+            text="Watch seed",
+            hours_per_week=0.0,
+            recurring=False,
+        ),
+    )
+
+    content_id = repo.upsert_content(
+        canonical_url=f"https://example.com/assign/{suffix}",
+        original_url=f"https://example.com/assign/{suffix}",
+        provider="test",
+        content_type="video",
+        title="Lecture on widgets",
+        duration_seconds=1800,  # 30 min
+    )
+
+    repo.assign_user_content_to_promise(user_id, content_id, "T54")
+
+    with get_db_session() as session:
+        promise_uuid = resolve_promise_uuid(session, user_id, "T54")
+    assert promise_uuid
+
+    sessions_repo = PlanSessionsRepository()
+    linked = [
+        s for s in sessions_repo.list_for_promise(promise_uuid, user_id)
+        if s.get("content_id") == content_id
+    ]
+    assert len(linked) == 1, "exactly one watch session should be created"
+    sess = linked[0]
+    assert sess["title"].startswith("Watch:"), sess["title"]
+    assert sess["planned_duration_min"] == 30
+    assert sess["status"] == "planned"
+
+    # Re-assigning the same content must not create a duplicate session.
+    repo.assign_user_content_to_promise(user_id, content_id, "T54")
+    linked_after = [
+        s for s in sessions_repo.list_for_promise(promise_uuid, user_id)
+        if s.get("content_id") == content_id
+    ]
+    assert len(linked_after) == 1, "re-assign must be deduped"
 
 
 def test_insert_consumption_event():

--- a/tm_bot/db/alembic/versions/023_session_content_link.py
+++ b/tm_bot/db/alembic/versions/023_session_content_link.py
@@ -1,0 +1,31 @@
+"""Add content_id to plan_sessions
+
+Lets a planned session reference the specific content item it is for
+(e.g. a "Watch: ..." session created when content is assigned to a
+promise). Nullable: ordinary user-created sessions have no content.
+
+Revision ID: 023_session_content_link
+Revises: 022_add_auth_sessions
+Create Date: 2026-05-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "023_session_content_link"
+down_revision: Union[str, None] = "022_add_auth_sessions"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("plan_sessions", sa.Column("content_id", sa.Text(), nullable=True))
+    op.create_index(
+        "ix_plan_sessions_content", "plan_sessions", ["content_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_plan_sessions_content", table_name="plan_sessions")
+    op.drop_column("plan_sessions", "content_id")

--- a/tm_bot/repositories/content_repo.py
+++ b/tm_bot/repositories/content_repo.py
@@ -2,12 +2,15 @@
 Repository for content catalog, user_content, consumption events, and rollup heatmaps.
 """
 import json
+import logging
 import uuid
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import text
 
 from db.postgres_db import get_db_session, utc_now_iso, resolve_promise_uuid
+
+logger = logging.getLogger(__name__)
 
 
 def _now() -> str:
@@ -173,7 +176,11 @@ class ContentRepository:
             return str(row["id"]) if row else uc_id
 
     def assign_user_content_to_promise(self, user_id: str, content_id: str, promise_id: str) -> str:
-        """Ensure content is saved and linked to a promise/task."""
+        """Ensure content is saved and linked to a promise/task.
+
+        Also creates a watch/read plan_session on the promise for this content
+        (deduped, best-effort) so the consumption shows up in the user's plan.
+        """
         # FK references promises.promise_uuid — resolve short current_id first
         promise_uuid = None
         try:
@@ -181,7 +188,60 @@ class ContentRepository:
                 promise_uuid = resolve_promise_uuid(session, str(user_id), str(promise_id))
         except Exception:
             pass
-        return self.add_user_content(str(user_id), str(content_id), assigned_promise_id=promise_uuid or str(promise_id))
+        uc_id = self.add_user_content(
+            str(user_id), str(content_id), assigned_promise_id=promise_uuid or str(promise_id)
+        )
+        # Session creation is best-effort: never let it break the assignment.
+        if promise_uuid:
+            self._ensure_watch_session(str(user_id), str(content_id), promise_uuid)
+        return uc_id
+
+    # Verb shown in the auto-created session title, keyed by content_type.
+    _SESSION_VERB_BY_TYPE = {
+        "video": "Watch",
+        "youtube": "Watch",
+        "pdf": "Read",
+        "article": "Read",
+        "blog": "Read",
+        "web": "Read",
+        "audio": "Listen",
+        "podcast": "Listen",
+    }
+
+    def _ensure_watch_session(self, user_id: str, content_id: str, promise_uuid: str) -> None:
+        """Create a single watch/read session for this content on the promise."""
+        try:
+            from repositories.plan_sessions_repo import PlanSessionsRepository
+
+            repo = PlanSessionsRepository()
+            if repo.find_for_content(promise_uuid, user_id, content_id):
+                return  # already has a session for this content
+
+            content = self.get_content_by_id(content_id) or {}
+            content_type = (content.get("content_type") or "").lower()
+            verb = self._SESSION_VERB_BY_TYPE.get(content_type, "Review")
+            title = (content.get("title") or content_type or "content").strip()
+            session_title = f"{verb}: {title}"[:200]
+
+            duration_min = None
+            duration_seconds = content.get("duration_seconds") or content.get("estimated_read_seconds")
+            if duration_seconds:
+                try:
+                    duration_min = max(1, round(float(duration_seconds) / 60.0))
+                except (TypeError, ValueError):
+                    duration_min = None
+
+            repo.create(
+                promise_uuid,
+                user_id,
+                {
+                    "title": session_title,
+                    "planned_duration_min": duration_min,
+                    "content_id": content_id,
+                },
+            )
+        except Exception as e:
+            logger.debug("Could not create watch/read session for content %s: %s", content_id, e)
 
     def get_user_content(self, user_id: str, content_id: str) -> Optional[Dict[str, Any]]:
         """Return single user_content row (with content) or None."""

--- a/tm_bot/repositories/plan_sessions_repo.py
+++ b/tm_bot/repositories/plan_sessions_repo.py
@@ -24,7 +24,7 @@ class PlanSessionsRepository:
             rows = session.execute(
                 text("""
                     SELECT id, promise_uuid, user_id, title, status,
-                           planned_start, planned_duration_min, notes, created_at
+                           planned_start, planned_duration_min, notes, content_id, created_at
                     FROM plan_sessions
                     WHERE promise_uuid = :promise_uuid AND user_id = :user_id
                     ORDER BY planned_start NULLS LAST, created_at
@@ -45,10 +45,10 @@ class PlanSessionsRepository:
             result = session.execute(
                 text("""
                     INSERT INTO plan_sessions
-                        (promise_uuid, user_id, title, status, planned_start, planned_duration_min, notes, created_at)
+                        (promise_uuid, user_id, title, status, planned_start, planned_duration_min, notes, content_id, created_at)
                     VALUES
-                        (:promise_uuid, :user_id, :title, 'planned', :planned_start, :planned_duration_min, :notes, :created_at)
-                    RETURNING id, promise_uuid, user_id, title, status, planned_start, planned_duration_min, notes, created_at
+                        (:promise_uuid, :user_id, :title, 'planned', :planned_start, :planned_duration_min, :notes, :content_id, :created_at)
+                    RETURNING id, promise_uuid, user_id, title, status, planned_start, planned_duration_min, notes, content_id, created_at
                 """),
                 {
                     "promise_uuid": promise_uuid,
@@ -57,6 +57,7 @@ class PlanSessionsRepository:
                     "planned_start": data.get("planned_start"),
                     "planned_duration_min": data.get("planned_duration_min"),
                     "notes": data.get("notes"),
+                    "content_id": data.get("content_id"),
                     "created_at": utc_now_iso(),
                 },
             ).mappings().fetchone()
@@ -77,6 +78,29 @@ class PlanSessionsRepository:
                 )
             checklist = self._get_checklist(session, session_id)
             return {**dict(result), "checklist": checklist}
+
+    def find_for_content(self, promise_uuid: str, user_id: int, content_id: str) -> Optional[dict]:
+        """Return an existing session linking this content to this promise, or None.
+
+        Used to avoid creating duplicate watch/read sessions when content is
+        re-assigned to the same promise.
+        """
+        user = str(user_id)
+        with get_db_session() as session:
+            row = session.execute(
+                text("""
+                    SELECT id, promise_uuid, user_id, title, status,
+                           planned_start, planned_duration_min, notes, content_id, created_at
+                    FROM plan_sessions
+                    WHERE promise_uuid = :promise_uuid
+                      AND user_id = :user_id
+                      AND content_id = :content_id
+                    ORDER BY created_at
+                    LIMIT 1
+                """),
+                {"promise_uuid": promise_uuid, "user_id": user, "content_id": content_id},
+            ).mappings().fetchone()
+            return dict(row) if row else None
 
     def get(self, session_id: int, user_id: int) -> Optional[dict]:
         user = str(user_id)


### PR DESCRIPTION
## What
Part of #54. When content is assigned to a promise, also create a **watch/read plan session** on that promise so the consumption shows up in the user's plan (My Week / promise detail).

Your note on #54: *"When assigning the content to promise, it should be automatically added to contents as well. And we might need to add a session to that promise for watching/reading this content. Adding pdf contents, and any other source of content should be treated this way."*

- "Auto-added to contents" was already handled by `assign_user_content_to_promise` (it upserts `user_content`).
- This PR adds the **session** half.

## How
Centralized in `ContentRepository.assign_user_content_to_promise`, so **all three assign paths** (Telegram video assign, the PDF/content callback, and the `youtube_watch` webapp router) get it for free — matching "any content source should be treated this way."

- **Migration 023** — add nullable `content_id` to `plan_sessions` (+ index). Ordinary user sessions have no content.
- `plan_sessions_repo` — `create()` persists `content_id`; new `find_for_content()` dedup helper; `list_for_promise()` now returns `content_id`.
- Session title is verb-aware by `content_type`: **Watch:** (video), **Read:** (pdf/article/blog/web), **Listen:** (audio/podcast), else **Review:**.
- `planned_duration_min` derived from `duration_seconds` (fallback `estimated_read_seconds`).
- `planned_start` left NULL → it's an unscheduled "to-do" session, so it won't trigger time-based reminders.
- **Best-effort**: a session-creation failure is caught and logged; it never breaks the assignment.
- **Deduped**: re-assigning the same content to the same promise does not create a second session.

## Test
`test_assign_content_to_promise_creates_deduped_watch_session` (requires_postgres): assigns a 30-min video to a promise, asserts exactly one `Watch:` session with `planned_duration_min == 30`, then re-assigns and asserts no duplicate.

## Migration / deploy note
Carries **migration 023** — apply with `alembic ... upgrade head` after deploy (per runbook). Until applied, session creation is a no-op (best-effort try/except), so assignment still works on the un-migrated DB.

## Not covered here (future #54 slices)
LLM-ranked promise picker, pause-aware time tracking. Tracked separately.

Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
