### PR TITLE
[codex] 2026-05-30 planned session reminders and scheduling UX

### DIFF
--- a/tests/unit/test_plan_session_reminder_service.py
+++ b/tests/unit/test_plan_session_reminder_service.py
@@ -1,0 +1,71 @@
+import pytest
+
+from services import plan_session_reminder_service as service_module
+
+
+class _FakePlanSessionsRepo:
+    def __init__(self, due_sessions):
+        self.due_sessions = due_sessions
+        self.marked = []
+
+    def list_sessions_needing_reminder(self, lookahead_minutes=1):
+        return list(self.due_sessions)
+
+    def mark_plan_session_notified(self, session_id):
+        self.marked.append(session_id)
+
+
+@pytest.mark.asyncio
+async def test_plan_session_reminder_service_sends_and_marks_notified(monkeypatch):
+    repo = _FakePlanSessionsRepo(
+        [
+            {
+                "id": 42,
+                "user_id": "123",
+                "promise_id": "P1",
+                "promise_text": "Write",
+                "title": "Draft",
+                "planned_start": "2026-05-30T12:00:00Z",
+                "planned_duration_min": 25,
+                "reminder_offset_min": 0,
+            }
+        ]
+    )
+    calls = []
+
+    async def _fake_send(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(service_module, "send_plan_session_reminder", _fake_send)
+
+    sent = await service_module.PlanSessionReminderService(repo).dispatch_due_reminders("token")
+
+    assert sent == 1
+    assert repo.marked == [42]
+    assert calls[0]["reminder_offset_min"] == 0
+    assert calls[0]["plan_session_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_plan_session_reminder_service_does_not_mark_failed_send(monkeypatch):
+    repo = _FakePlanSessionsRepo(
+        [
+            {
+                "id": 7,
+                "user_id": "123",
+                "promise_id": "P1",
+                "promise_text": "Write",
+                "planned_start": "2026-05-30T12:00:00Z",
+            }
+        ]
+    )
+
+    async def _fake_send(**kwargs):
+        raise RuntimeError("network")
+
+    monkeypatch.setattr(service_module, "send_plan_session_reminder", _fake_send)
+
+    sent = await service_module.PlanSessionReminderService(repo).dispatch_due_reminders("token")
+
+    assert sent == 0
+    assert repo.marked == []

--- a/tm_bot/db/alembic/versions/024_plan_session_reminder_preferences.py
+++ b/tm_bot/db/alembic/versions/024_plan_session_reminder_preferences.py
@@ -1,0 +1,38 @@
+"""Add reminder preferences to plan_sessions
+
+Revision ID: 024_plan_session_reminder_preferences
+Revises: 023_session_content_link
+Create Date: 2026-05-30
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "024_plan_session_reminder_preferences"
+down_revision: Union[str, None] = "023_session_content_link"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "plan_sessions",
+        sa.Column("reminder_enabled", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "plan_sessions",
+        sa.Column("reminder_offset_min", sa.Integer(), nullable=False, server_default="10"),
+    )
+    op.create_index(
+        "ix_plan_sessions_reminders_due",
+        "plan_sessions",
+        ["status", "reminder_enabled", "notified_at", "planned_start"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_plan_sessions_reminders_due", table_name="plan_sessions")
+    op.drop_column("plan_sessions", "reminder_offset_min")
+    op.drop_column("plan_sessions", "reminder_enabled")

--- a/tm_bot/handlers/callback_handlers.py
+++ b/tm_bot/handlers/callback_handlers.py
@@ -464,6 +464,10 @@ class CallbackHandlers:
         elif action == "psess_del":
             plan_session_id = cb.get("sid")
             await self._handle_plan_session_delete(query, plan_session_id, user_lang)
+        elif action in {"psess_done", "psess_skip"}:
+            plan_session_id = cb.get("sid")
+            status = "done" if action == "psess_done" else "skipped"
+            await self._handle_plan_session_status(query, plan_session_id, status, user_lang)
         elif action == "club_cancel":
             await self._handle_club_cancel(query, cb.get("cid"), user_lang)
         elif action == "club_remind":
@@ -1005,13 +1009,6 @@ class CallbackHandlers:
         user_id = query.from_user.id
         try:
             sess = self.plan_keeper.sessions_service.start(user_id, promise_id)
-            # Mark the plan session as done now that the user is starting it
-            try:
-                self.plan_keeper.plan_sessions_repo.update_status(
-                    int(plan_session_id), user_id, "done"
-                )
-            except Exception:
-                pass  # Non-critical; focus session is already started
             message = get_message("session_started", user_lang, promise_id=promise_id)
             if not message or message == "session_started":
                 message = f"▶️ Focus session started for *#{promise_id}*!\n\nGood luck! 🎯"
@@ -1031,7 +1028,9 @@ class CallbackHandlers:
         try:
             from datetime import datetime, timezone, timedelta
             minutes_int = int(minutes or 60)
-            new_start = (datetime.now(timezone.utc) + timedelta(minutes=minutes_int)).isoformat()
+            new_start = (
+                datetime.now(timezone.utc) + timedelta(minutes=minutes_int)
+            ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
             result = self.plan_keeper.plan_sessions_repo.snooze_plan_session(
                 session_id=int(plan_session_id),
                 user_id=user_id,
@@ -1065,6 +1064,21 @@ class CallbackHandlers:
         except Exception as e:
             logger.error(f"Failed to delete plan_session {plan_session_id}: {e}")
             await query.answer("Failed to delete. Please try from the app.", show_alert=True)
+
+    async def _handle_plan_session_status(self, query, plan_session_id: str, status: str, user_lang: Language):
+        """Handle marking a planned session done or skipped from the reminder."""
+        user_id = query.from_user.id
+        try:
+            result = self.plan_keeper.plan_sessions_repo.update_status(int(plan_session_id), user_id, status)
+            if not result:
+                await query.answer("Session not found.", show_alert=True)
+                return
+            title = result.get("title") or "Session"
+            message = f"Done: {title}" if status == "done" else f"Skipped: {title}"
+            await query.edit_message_text(message, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(f"Failed to update plan_session {plan_session_id} to {status}: {e}")
+            await query.answer("Failed to update session. Please try from the app.", show_alert=True)
 
     @staticmethod
     def _parse_utc_datetime(value: Optional[str]) -> Optional[datetime]:

--- a/tm_bot/models/models.py
+++ b/tm_bot/models/models.py
@@ -116,6 +116,8 @@ class PlanSession:
     planned_duration_min: Optional[int] = None
     notes: Optional[str] = None
     created_at: Optional[str] = None
+    reminder_enabled: bool = True
+    reminder_offset_min: int = 10
 
 
 @dataclass

--- a/tm_bot/planner_bot.py
+++ b/tm_bot/planner_bot.py
@@ -2291,6 +2291,16 @@ class PlannerBot:
         except Exception as exc:
             logger.exception("bootstrap_schedule_existing_users: failed to schedule promise_reminder_tick: %s", exc)
 
+        try:
+            job_scheduler.schedule_repeating(
+                name="plan_session_reminder_tick",
+                callback=self._dispatch_plan_session_reminders,
+                seconds=60,
+            )
+            logger.info("bootstrap_schedule_existing_users: scheduled plan_session_reminder_tick every 60 sec")
+        except Exception as exc:
+            logger.exception("bootstrap_schedule_existing_users: failed to schedule plan_session_reminder_tick: %s", exc)
+
     def run(self) -> None:
         """
         Start the bot. For Telegram this runs polling; for other platforms, their event loop.
@@ -2357,6 +2367,21 @@ class PlannerBot:
                 await bot.send_message(chat_id=user_id, text=msg)
             except Exception as exc:
                 logger.warning("[PromiseReminder] Failed to send to user %s: %s", user_id, exc)
+
+    async def _dispatch_plan_session_reminders(self, context) -> None:
+        """Scheduled callback (every 60 sec): send due planned-session reminders."""
+        bot_token = os.getenv("BOT_TOKEN") or os.getenv("TELEGRAM_BOT_TOKEN")
+        if not bot_token:
+            logger.warning("[PlanSessionReminder] No bot token configured; skipping tick")
+            return
+        try:
+            from services.plan_session_reminder_service import PlanSessionReminderService
+
+            sent = await PlanSessionReminderService().dispatch_due_reminders(bot_token=bot_token)
+            if sent:
+                logger.info("[PlanSessionReminder] Sent %d planned-session reminder(s)", sent)
+        except Exception as exc:
+            logger.exception("[PlanSessionReminder] Tick failed: %s", exc)
 
 
 def main():

--- a/tm_bot/repositories/plan_sessions_repo.py
+++ b/tm_bot/repositories/plan_sessions_repo.py
@@ -9,6 +9,21 @@ from sqlalchemy import text
 from db.postgres_db import get_db_session, resolve_promise_uuid, utc_now_iso
 
 
+PLAN_SESSION_SELECT = """
+    id, promise_uuid, user_id, title, status, planned_start,
+    planned_duration_min, notes, content_id, created_at, notified_at,
+    reminder_enabled, reminder_offset_min
+"""
+
+
+def _row_to_dict(row) -> dict:
+    data = dict(row)
+    data["reminder_enabled"] = bool(data.get("reminder_enabled", True))
+    if data.get("reminder_offset_min") is None:
+        data["reminder_offset_min"] = 10
+    return data
+
+
 class PlanSessionsRepository:
 
     def __init__(self) -> None:
@@ -22,9 +37,8 @@ class PlanSessionsRepository:
         user = str(user_id)
         with get_db_session() as session:
             rows = session.execute(
-                text("""
-                    SELECT id, promise_uuid, user_id, title, status,
-                           planned_start, planned_duration_min, notes, content_id, created_at
+                text(f"""
+                    SELECT {PLAN_SESSION_SELECT}
                     FROM plan_sessions
                     WHERE promise_uuid = :promise_uuid AND user_id = :user_id
                     ORDER BY planned_start NULLS LAST, created_at
@@ -35,20 +49,28 @@ class PlanSessionsRepository:
             results = []
             for r in rows:
                 checklist = self._get_checklist(session, r["id"])
-                results.append({**dict(r), "checklist": checklist})
+                results.append({**_row_to_dict(r), "checklist": checklist})
             return results
 
     def create(self, promise_uuid: str, user_id: int, data: dict) -> dict:
         user = str(user_id)
         checklist_data = data.pop("checklist", [])
+        reminder_enabled = data.get("reminder_enabled", True)
+        reminder_offset_min = data.get("reminder_offset_min", 10)
         with get_db_session() as session:
             result = session.execute(
                 text("""
                     INSERT INTO plan_sessions
-                        (promise_uuid, user_id, title, status, planned_start, planned_duration_min, notes, content_id, created_at)
+                        (promise_uuid, user_id, title, status, planned_start,
+                         planned_duration_min, notes, content_id, created_at,
+                         reminder_enabled, reminder_offset_min)
                     VALUES
-                        (:promise_uuid, :user_id, :title, 'planned', :planned_start, :planned_duration_min, :notes, :content_id, :created_at)
-                    RETURNING id, promise_uuid, user_id, title, status, planned_start, planned_duration_min, notes, content_id, created_at
+                        (:promise_uuid, :user_id, :title, 'planned', :planned_start,
+                         :planned_duration_min, :notes, :content_id, :created_at,
+                         :reminder_enabled, :reminder_offset_min)
+                    RETURNING id, promise_uuid, user_id, title, status, planned_start,
+                              planned_duration_min, notes, content_id, created_at,
+                              notified_at, reminder_enabled, reminder_offset_min
                 """),
                 {
                     "promise_uuid": promise_uuid,
@@ -59,6 +81,8 @@ class PlanSessionsRepository:
                     "notes": data.get("notes"),
                     "content_id": data.get("content_id"),
                     "created_at": utc_now_iso(),
+                    "reminder_enabled": 1 if reminder_enabled else 0,
+                    "reminder_offset_min": int(reminder_offset_min),
                 },
             ).mappings().fetchone()
 
@@ -77,7 +101,7 @@ class PlanSessionsRepository:
                     },
                 )
             checklist = self._get_checklist(session, session_id)
-            return {**dict(result), "checklist": checklist}
+            return {**_row_to_dict(result), "checklist": checklist}
 
     def find_for_content(self, promise_uuid: str, user_id: int, content_id: str) -> Optional[dict]:
         """Return an existing session linking this content to this promise, or None.
@@ -88,9 +112,8 @@ class PlanSessionsRepository:
         user = str(user_id)
         with get_db_session() as session:
             row = session.execute(
-                text("""
-                    SELECT id, promise_uuid, user_id, title, status,
-                           planned_start, planned_duration_min, notes, content_id, created_at
+                text(f"""
+                    SELECT {PLAN_SESSION_SELECT}
                     FROM plan_sessions
                     WHERE promise_uuid = :promise_uuid
                       AND user_id = :user_id
@@ -100,15 +123,14 @@ class PlanSessionsRepository:
                 """),
                 {"promise_uuid": promise_uuid, "user_id": user, "content_id": content_id},
             ).mappings().fetchone()
-            return dict(row) if row else None
+            return _row_to_dict(row) if row else None
 
     def get(self, session_id: int, user_id: int) -> Optional[dict]:
         user = str(user_id)
         with get_db_session() as session:
             row = session.execute(
-                text("""
-                    SELECT id, promise_uuid, user_id, title, status,
-                           planned_start, planned_duration_min, notes, created_at
+                text(f"""
+                    SELECT {PLAN_SESSION_SELECT}
                     FROM plan_sessions
                     WHERE id = :session_id AND user_id = :user_id
                 """),
@@ -117,23 +139,23 @@ class PlanSessionsRepository:
             if not row:
                 return None
             checklist = self._get_checklist(session, row["id"])
-            return {**dict(row), "checklist": checklist}
+            return {**_row_to_dict(row), "checklist": checklist}
 
     def update_status(self, session_id: int, user_id: int, status: str) -> Optional[dict]:
         user = str(user_id)
         with get_db_session() as session:
             result = session.execute(
-                text("""
+                text(f"""
                     UPDATE plan_sessions SET status = :status
                     WHERE id = :session_id AND user_id = :user_id
-                    RETURNING id, promise_uuid, user_id, title, status, planned_start, planned_duration_min, notes, created_at
+                    RETURNING {PLAN_SESSION_SELECT}
                 """),
                 {"status": status, "session_id": session_id, "user_id": user},
             ).mappings().fetchone()
             if not result:
                 return None
             checklist = self._get_checklist(session, result["id"])
-            return {**dict(result), "checklist": checklist}
+            return {**_row_to_dict(result), "checklist": checklist}
 
     def delete(self, session_id: int, user_id: int) -> bool:
         user = str(user_id)
@@ -145,28 +167,38 @@ class PlanSessionsRepository:
             return result.rowcount > 0
 
     def update(self, session_id: int, user_id: int, data: dict) -> Optional[dict]:
-        """Patch mutable fields (title, planned_start, planned_duration_min, notes)."""
+        """Patch mutable fields for a planned session."""
         user = str(user_id)
-        allowed = {"title", "planned_start", "planned_duration_min", "notes"}
+        allowed = {
+            "title",
+            "planned_start",
+            "planned_duration_min",
+            "notes",
+            "reminder_enabled",
+            "reminder_offset_min",
+        }
         fields = {k: v for k, v in data.items() if k in allowed}
         if not fields:
             return self.get(session_id, int(user_id))
+        if "reminder_enabled" in fields:
+            fields["reminder_enabled"] = 1 if fields["reminder_enabled"] else 0
         set_clause = ", ".join(f"{k} = :{k}" for k in fields)
+        if "planned_start" in fields or "reminder_offset_min" in fields or "reminder_enabled" in fields:
+            set_clause += ", notified_at = NULL"
         params = {**fields, "session_id": session_id, "user_id": user}
         with get_db_session() as session:
             result = session.execute(
                 text(f"""
                     UPDATE plan_sessions SET {set_clause}
                     WHERE id = :session_id AND user_id = :user_id
-                    RETURNING id, promise_uuid, user_id, title, status,
-                              planned_start, planned_duration_min, notes, created_at
+                    RETURNING {PLAN_SESSION_SELECT}
                 """),
                 params,
             ).mappings().fetchone()
             if not result:
                 return None
             checklist = self._get_checklist(session, result["id"])
-            return {**dict(result), "checklist": checklist}
+            return {**_row_to_dict(result), "checklist": checklist}
 
     # ------------------------------------------------------------------
     # Checklist items
@@ -197,41 +229,54 @@ class PlanSessionsRepository:
     # ------------------------------------------------------------------
 
     def list_sessions_needing_reminder(self, lookahead_minutes: int = 1) -> List[dict]:
-        """Find planned sessions whose planned_start is at or before (now + lookahead_minutes)
-        that haven't been notified yet.  Only sessions with status='planned' are returned.
-        To avoid notifying for very stale sessions, we ignore sessions whose planned_start
-        is more than 30 minutes in the past.
-        """
-        from db.postgres_db import utc_now_iso
-        from datetime import datetime, timezone, timedelta
+        """Find planned sessions whose reminder window is due.
 
-        now_utc = datetime.now(timezone.utc)
-        lower_bound = (now_utc - timedelta(minutes=30)).isoformat()
-        upper_bound = (now_utc + timedelta(minutes=lookahead_minutes)).isoformat()
+        The reminder time is planned_start minus reminder_offset_min. To avoid
+        notifying for very stale sessions, ignore sessions whose planned_start is
+        more than 30 minutes in the past.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        now_utc = datetime.now(timezone.utc).replace(microsecond=0)
+        lower_bound = (now_utc - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
+        max_upper_bound = (now_utc + timedelta(minutes=1440 + lookahead_minutes)).isoformat().replace("+00:00", "Z")
 
         with get_db_session() as session:
             rows = session.execute(
                 text("""
                     SELECT ps.id, ps.promise_uuid, ps.user_id, ps.title, ps.status,
-                           ps.planned_start, ps.planned_duration_min, ps.notes, ps.created_at,
-                           ps.notified_at,
+                           ps.planned_start, ps.planned_duration_min, ps.notes, ps.content_id,
+                           ps.created_at, ps.notified_at, ps.reminder_enabled,
+                           ps.reminder_offset_min,
                            p.current_id AS promise_id, p.text AS promise_text
                     FROM plan_sessions ps
                     LEFT JOIN promises p ON p.promise_uuid = ps.promise_uuid
                     WHERE ps.status = 'planned'
+                      AND ps.reminder_enabled = 1
                       AND ps.planned_start IS NOT NULL
                       AND ps.planned_start >= :lower_bound
-                      AND ps.planned_start <= :upper_bound
+                      AND ps.planned_start <= :max_upper_bound
                       AND ps.notified_at IS NULL
                     ORDER BY ps.planned_start
                 """),
-                {"lower_bound": lower_bound, "upper_bound": upper_bound},
+                {"lower_bound": lower_bound, "max_upper_bound": max_upper_bound},
             ).mappings().fetchall()
-            return [dict(r) for r in rows]
+
+            due = []
+            for r in rows:
+                data = _row_to_dict(r)
+                try:
+                    planned_start = datetime.fromisoformat(str(data["planned_start"]).replace("Z", "+00:00"))
+                    offset = data.get("reminder_offset_min")
+                    reminder_at = planned_start - timedelta(minutes=int(10 if offset is None else offset))
+                    if reminder_at <= now_utc + timedelta(minutes=lookahead_minutes):
+                        due.append(data)
+                except Exception:
+                    continue
+            return due
 
     def mark_plan_session_notified(self, session_id: int) -> None:
         """Mark a planned session as notified by setting notified_at to now."""
-        from db.postgres_db import utc_now_iso
         with get_db_session() as session:
             session.execute(
                 text("""
@@ -242,24 +287,31 @@ class PlanSessionsRepository:
                 {"session_id": session_id, "notified_at": utc_now_iso()},
             )
 
+    def clear_plan_session_notified(self, session_id: int) -> None:
+        """Clear notified_at so a failed reminder can be retried."""
+        with get_db_session() as session:
+            session.execute(
+                text("UPDATE plan_sessions SET notified_at = NULL WHERE id = :session_id"),
+                {"session_id": session_id},
+            )
+
     def snooze_plan_session(self, session_id: int, user_id: int, new_planned_start: str) -> Optional[dict]:
         """Update planned_start and reset notified_at so a new reminder will fire."""
         user = str(user_id)
         with get_db_session() as session:
             result = session.execute(
-                text("""
+                text(f"""
                     UPDATE plan_sessions
-                    SET planned_start = :planned_start, notified_at = NULL
+                    SET planned_start = :planned_start, notified_at = NULL, reminder_offset_min = 0
                     WHERE id = :session_id AND user_id = :user_id
-                    RETURNING id, promise_uuid, user_id, title, status,
-                              planned_start, planned_duration_min, notes, created_at, notified_at
+                    RETURNING {PLAN_SESSION_SELECT}
                 """),
                 {"session_id": session_id, "user_id": user, "planned_start": new_planned_start},
             ).mappings().fetchone()
             if not result:
                 return None
             checklist = self._get_checklist(session, result["id"])
-            return {**dict(result), "checklist": checklist}
+            return {**_row_to_dict(result), "checklist": checklist}
 
     def list_planned_by_promise_uuids(self, promise_uuids: List[str], user_id: int) -> dict:
         """Bulk-fetch all planned sessions for a list of promise_uuids, grouped by promise_uuid."""
@@ -270,7 +322,8 @@ class PlanSessionsRepository:
             rows = session.execute(
                 text("""
                     SELECT id, promise_uuid, title, status,
-                           planned_start, planned_duration_min, notes, created_at
+                           planned_start, planned_duration_min, notes, content_id,
+                           created_at, notified_at, reminder_enabled, reminder_offset_min
                     FROM plan_sessions
                     WHERE promise_uuid = ANY(:uuids) AND user_id = :user_id
                       AND status = 'planned'
@@ -284,7 +337,7 @@ class PlanSessionsRepository:
             uuid = r["promise_uuid"]
             if uuid not in result:
                 result[uuid] = []
-            result[uuid].append(dict(r))
+            result[uuid].append(_row_to_dict(r))
         return result
 
     def list_upcoming_for_user(self, user_id: int, since_iso: str, until_iso: str) -> List[dict]:
@@ -298,7 +351,9 @@ class PlanSessionsRepository:
             rows = session.execute(
                 text("""
                     SELECT ps.id, ps.promise_uuid, ps.user_id, ps.title, ps.status,
-                           ps.planned_start, ps.planned_duration_min, ps.notes, ps.created_at,
+                           ps.planned_start, ps.planned_duration_min, ps.notes, ps.content_id,
+                           ps.created_at, ps.notified_at, ps.reminder_enabled,
+                           ps.reminder_offset_min,
                            p.current_id AS promise_id, p.text AS promise_text
                     FROM plan_sessions ps
                     LEFT JOIN promises p ON p.promise_uuid = ps.promise_uuid
@@ -310,7 +365,7 @@ class PlanSessionsRepository:
                 """),
                 {"user_id": user, "since_iso": since_iso, "until_iso": until_iso},
             ).mappings().fetchall()
-            return [dict(r) for r in rows]
+            return [_row_to_dict(r) for r in rows]
 
     @staticmethod
     def _get_checklist(session, plan_session_id: int) -> List[dict]:

--- a/tm_bot/services/plan_session_reminder_service.py
+++ b/tm_bot/services/plan_session_reminder_service.py
@@ -1,0 +1,53 @@
+"""Dispatch Telegram reminders for due planned sessions."""
+
+from repositories.plan_sessions_repo import PlanSessionsRepository
+from utils.logger import get_logger
+from webapp.notifications import send_plan_session_reminder
+
+
+logger = get_logger(__name__)
+
+
+class PlanSessionReminderService:
+    """Find due planned sessions and send their Telegram reminders."""
+
+    def __init__(self, repo: PlanSessionsRepository | None = None) -> None:
+        self.repo = repo or PlanSessionsRepository()
+
+    async def dispatch_due_reminders(
+        self,
+        bot_token: str,
+        lookahead_minutes: int = 1,
+        limit: int = 100,
+    ) -> int:
+        due_sessions = self.repo.list_sessions_needing_reminder(lookahead_minutes=lookahead_minutes)
+        sent = 0
+
+        for ps in due_sessions[:limit]:
+            plan_session_id = int(ps["id"])
+            user_id = int(ps["user_id"])
+            try:
+                offset = ps.get("reminder_offset_min")
+                await send_plan_session_reminder(
+                    bot_token=bot_token,
+                    user_id=user_id,
+                    plan_session_id=plan_session_id,
+                    promise_id=ps.get("promise_id") or "",
+                    promise_text=ps.get("promise_text") or "Promise",
+                    title=ps.get("title"),
+                    planned_start=ps.get("planned_start"),
+                    planned_duration_min=ps.get("planned_duration_min"),
+                    reminder_offset_min=int(10 if offset is None else offset),
+                )
+                self.repo.mark_plan_session_notified(plan_session_id)
+                sent += 1
+            except Exception as exc:
+                logger.error(
+                    "Failed to send planned session reminder %s to user %s: %s",
+                    plan_session_id,
+                    user_id,
+                    exc,
+                    exc_info=True,
+                )
+
+        return sent

--- a/tm_bot/services/planner_api_adapter.py
+++ b/tm_bot/services/planner_api_adapter.py
@@ -1742,6 +1742,16 @@ class PlannerAPIAdapter:
             notes: Optional notes for this session
         """
         try:
+            if planned_start:
+                try:
+                    from datetime import timezone
+
+                    parsed_start = datetime.fromisoformat(str(planned_start).replace("Z", "+00:00"))
+                    if parsed_start.tzinfo is None:
+                        parsed_start = parsed_start.replace(tzinfo=timezone.utc)
+                    planned_start = parsed_start.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+                except Exception:
+                    pass
             with get_db_session() as session:
                 p_uuid = resolve_promise_uuid(session, str(user_id), promise_id)
             if not p_uuid:

--- a/tm_bot/webapp/api.py
+++ b/tm_bot/webapp/api.py
@@ -282,6 +282,7 @@ def create_webapp_api(
                             promise_id = ps.get("promise_id") or ""
                             promise_text = ps.get("promise_text") or f"Promise {promise_id}"
 
+                            offset = ps.get("reminder_offset_min")
                             await send_plan_session_reminder(
                                 bot_token=bot_token,
                                 user_id=user_id,
@@ -291,6 +292,7 @@ def create_webapp_api(
                                 title=ps.get("title"),
                                 planned_start=ps.get("planned_start"),
                                 planned_duration_min=ps.get("planned_duration_min"),
+                                reminder_offset_min=int(10 if offset is None else offset),
                             )
                             plan_sessions_repo.mark_plan_session_notified(plan_session_id)
                             logger.info(
@@ -308,7 +310,8 @@ def create_webapp_api(
                     logger.error(f"Error in plan session reminder sweeper: {e}", exc_info=True)
                     await asyncio.sleep(60)  # Wait longer on error
 
-        asyncio.create_task(plan_session_reminder_sweeper())
+        if os.getenv("WEBAPP_PLAN_SESSION_REMINDER_SWEEPER", "0") == "1":
+            asyncio.create_task(plan_session_reminder_sweeper())
         logger.info("✓ Started plan session reminder sweeper (checks every 60 seconds)")
 
         # Start content learning pipeline dispatcher (every 5 seconds when enabled)

--- a/tm_bot/webapp/notifications.py
+++ b/tm_bot/webapp/notifications.py
@@ -529,6 +529,7 @@ async def send_plan_session_reminder(
     title: Optional[str],
     planned_start: Optional[str],
     planned_duration_min: Optional[int],
+    reminder_offset_min: int = 10,
 ) -> None:
     """
     Send a Telegram reminder when a planned session is about to start.
@@ -572,6 +573,18 @@ async def send_plan_session_reminder(
             parts.append(f"🕐 {time_str}" + (f"  ·  {dur_str}" if dur_str else ""))
         elif dur_str:
             parts.append(f"⏱ {dur_str}")
+        heading = (
+            f"Reminder: starts in {reminder_offset_min} min"
+            if reminder_offset_min > 0
+            else "Time to focus"
+        )
+        parts = [f"*{heading}*\n\n{session_label}"]
+        if promise_text and promise_text.strip() and promise_text.strip() != session_label:
+            parts.append(f"Promise: {promise_text.strip()}")
+        if time_str:
+            parts.append(f"Start: {time_str}" + (f"  -  {dur_str}" if dur_str else ""))
+        elif dur_str:
+            parts.append(f"Duration: {dur_str}")
         message = "\n".join(parts)
 
         # Build inline keyboard (3 rows)
@@ -581,6 +594,16 @@ async def send_plan_session_reminder(
                     "▶️ Start Focus",
                     callback_data=encode_cb("psess_start", sid=str(plan_session_id), pid=promise_id),
                 )
+            ],
+            [
+                InlineKeyboardButton(
+                    "Done",
+                    callback_data=encode_cb("psess_done", sid=str(plan_session_id)),
+                ),
+                InlineKeyboardButton(
+                    "Skip",
+                    callback_data=encode_cb("psess_skip", sid=str(plan_session_id)),
+                ),
             ],
             [
                 InlineKeyboardButton(

--- a/tm_bot/webapp/routers/plan_sessions.py
+++ b/tm_bot/webapp/routers/plan_sessions.py
@@ -2,6 +2,9 @@
 Plan session endpoints: Promise → PlanSessions → Checklist.
 """
 
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
 from fastapi import APIRouter, HTTPException, Depends
 
 from ..dependencies import get_current_user
@@ -13,6 +16,7 @@ from ..schemas import (
     ChecklistItemToggle,
 )
 from repositories.plan_sessions_repo import PlanSessionsRepository
+from repositories.settings_repo import SettingsRepository
 from db.postgres_db import get_db_session, resolve_promise_uuid
 from utils.logger import get_logger
 
@@ -27,6 +31,37 @@ def _resolve_uuid(user_id: int, promise_id: str) -> str:
     if not p_uuid:
         raise HTTPException(status_code=404, detail="Promise not found")
     return p_uuid
+
+
+def _user_timezone(user_id: int) -> ZoneInfo:
+    try:
+        settings = SettingsRepository().get_settings(user_id)
+        tz_name = settings.timezone if settings and settings.timezone else "UTC"
+        if tz_name == "DEFAULT" or tz_name == "DISABLED":
+            tz_name = "UTC"
+        return ZoneInfo(tz_name)
+    except Exception:
+        return ZoneInfo("UTC")
+
+
+def _normalize_planned_start(value: str | None, user_id: int) -> str | None:
+    if not value:
+        return value
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid planned_start datetime") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_user_timezone(user_id))
+    return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _session_payload(data: dict, user_id: int) -> dict:
+    if "planned_start" in data:
+        data["planned_start"] = _normalize_planned_start(data.get("planned_start"), user_id)
+    if data.get("reminder_offset_min") is not None:
+        data["reminder_offset_min"] = int(data["reminder_offset_min"])
+    return data
 
 
 @router.get("/promises/{promise_id}/plan-sessions", response_model=list[PlanSessionOut])
@@ -45,7 +80,7 @@ async def create_plan_session(
     user_id: int = Depends(get_current_user),
 ):
     p_uuid = _resolve_uuid(user_id, promise_id)
-    return PlanSessionsRepository().create(p_uuid, user_id, body.model_dump())
+    return PlanSessionsRepository().create(p_uuid, user_id, _session_payload(body.model_dump(), user_id))
 
 
 @router.patch("/plan-sessions/{session_id}/status", response_model=PlanSessionOut)
@@ -90,7 +125,11 @@ async def update_plan_session(
     body: PlanSessionUpdate,
     user_id: int = Depends(get_current_user),
 ):
-    result = PlanSessionsRepository().update(session_id, user_id, body.model_dump(exclude_none=True))
+    result = PlanSessionsRepository().update(
+        session_id,
+        user_id,
+        _session_payload(body.model_dump(exclude_none=True), user_id),
+    )
     if not result:
         raise HTTPException(status_code=404, detail="Session not found")
     return result

--- a/tm_bot/webapp/schemas.py
+++ b/tm_bot/webapp/schemas.py
@@ -674,6 +674,8 @@ class PlanSessionIn(BaseModel):
     planned_start: Optional[str] = None
     planned_duration_min: Optional[int] = None
     notes: Optional[str] = None
+    reminder_enabled: bool = True
+    reminder_offset_min: int = Field(default=10, ge=0, le=1440)
     checklist: List[PlanChecklistItemIn] = []
 
 
@@ -686,6 +688,8 @@ class PlanSessionOut(BaseModel):
     planned_duration_min: Optional[int]
     notes: Optional[str]
     created_at: str
+    reminder_enabled: bool = True
+    reminder_offset_min: int = 10
     checklist: List[PlanChecklistItemOut]
 
 
@@ -698,6 +702,8 @@ class PlanSessionUpdate(BaseModel):
     planned_start: Optional[str] = None
     planned_duration_min: Optional[int] = None
     notes: Optional[str] = None
+    reminder_enabled: Optional[bool] = None
+    reminder_offset_min: Optional[int] = Field(default=None, ge=0, le=1440)
 
 
 class ChecklistItemToggle(BaseModel):

--- a/webapp_frontend/src/api/client.ts
+++ b/webapp_frontend/src/api/client.ts
@@ -1393,7 +1393,7 @@ class ApiClient {
     return this.request(`/plan-sessions/${sessionId}`, { method: 'DELETE' });
   }
 
-  async updatePlanSession(sessionId: number, data: { title?: string; planned_start?: string; planned_duration_min?: number; notes?: string }): Promise<import('../types').PlanSession> {
+  async updatePlanSession(sessionId: number, data: { title?: string; planned_start?: string; planned_duration_min?: number; notes?: string; reminder_enabled?: boolean; reminder_offset_min?: number }): Promise<import('../types').PlanSession> {
     return this.request(`/plan-sessions/${sessionId}`, {
       method: 'PATCH',
       body: JSON.stringify(data),

--- a/webapp_frontend/src/components/PromiseCard.tsx
+++ b/webapp_frontend/src/components/PromiseCard.tsx
@@ -20,6 +20,22 @@ interface PromiseCardProps {
 
 const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
 type PromiseProgressTone = 'strong' | 'on-track' | 'attention' | 'risk';
+type PlanSessionFormState = {
+  title: string;
+  planned_start: string;
+  planned_duration_min: string;
+  notes: string;
+  reminder_enabled: boolean;
+  reminder_offset_min: string;
+};
+
+const REMINDER_OFFSET_OPTIONS = [
+  { value: 0, label: 'At start' },
+  { value: 5, label: '5m before' },
+  { value: 10, label: '10m before' },
+  { value: 30, label: '30m before' },
+  { value: 60, label: '1h before' },
+];
 
 function formatDateTimeLocal(date: Date): string {
   const year = date.getFullYear();
@@ -30,12 +46,40 @@ function formatDateTimeLocal(date: Date): string {
   return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
+function datetimeLocalFromIso(value: string | null | undefined): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.slice(0, 16);
+  return formatDateTimeLocal(date);
+}
+
+function datetimeLocalToIso(value: string): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toISOString();
+}
+
 function roundUpToNextQuarterHour(date: Date): Date {
   const rounded = new Date(date);
   const minutes = rounded.getMinutes();
   const nextMinutes = Math.ceil((minutes + 1) / 15) * 15;
   rounded.setMinutes(nextMinutes, 0, 0);
   return rounded;
+}
+
+function shiftDateTimeLocal(value: string, minutes: number): string {
+  const base = value ? new Date(value) : new Date();
+  if (Number.isNaN(base.getTime())) return value;
+  base.setMinutes(base.getMinutes() + minutes);
+  return formatDateTimeLocal(base);
+}
+
+function reminderLabel(session: PlanSession): string {
+  if (!session.reminder_enabled) return 'No reminder';
+  const offset = session.reminder_offset_min ?? 10;
+  const match = REMINDER_OFFSET_OPTIONS.find(option => option.value === offset);
+  return match ? match.label : `${offset}m before`;
 }
 
 /**
@@ -140,7 +184,14 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
   const [expandedChipId, setExpandedChipId] = useState<number | null>(null);
   // Which session is open for inline editing
   const [editingSessionId, setEditingSessionId] = useState<number | null>(null);
-  const [editForm, setEditForm] = useState({ title: '', planned_start: '', planned_duration_min: '', notes: '' });
+  const [editForm, setEditForm] = useState<PlanSessionFormState>({
+    title: '',
+    planned_start: '',
+    planned_duration_min: '',
+    notes: '',
+    reminder_enabled: true,
+    reminder_offset_min: '10',
+  });
   const [editFormSaving, setEditFormSaving] = useState(false);
   const [activeDurationPicker, setActiveDurationPicker] = useState<'add' | 'edit' | null>(null);
 
@@ -148,12 +199,13 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
     setEditingSessionId(session.id);
     setExpandedChipId(null);
     setActiveDurationPicker(null);
-    const isoStart = session.planned_start ?? '';
     setEditForm({
       title: session.title ?? '',
-      planned_start: isoStart ? isoStart.substring(0, 16) : '', // datetime-local needs YYYY-MM-DDTHH:MM
+      planned_start: datetimeLocalFromIso(session.planned_start),
       planned_duration_min: session.planned_duration_min?.toString() ?? '',
       notes: session.notes ?? '',
+      reminder_enabled: session.reminder_enabled ?? true,
+      reminder_offset_min: String(session.reminder_offset_min ?? 10),
     });
   };
 
@@ -164,9 +216,11 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
     try {
       const updated = await apiClient.updatePlanSession(editingSessionId, {
         title: editForm.title || undefined,
-        planned_start: editForm.planned_start || undefined,
+        planned_start: datetimeLocalToIso(editForm.planned_start),
         planned_duration_min: editForm.planned_duration_min ? Number(editForm.planned_duration_min) : undefined,
         notes: editForm.notes || undefined,
+        reminder_enabled: editForm.reminder_enabled,
+        reminder_offset_min: Number(editForm.reminder_offset_min),
       });
       setPlanSessions(prev => prev.map(s => s.id === updated.id ? updated : s));
       setEditingSessionId(null);
@@ -179,7 +233,14 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
   const [logDoneSessionId, setLogDoneSessionId] = useState<number | null>(null);
   // Inline add-session form
   const [showAddForm, setShowAddForm] = useState(false);
-  const [addForm, setAddForm] = useState({ title: '', planned_start: '', planned_duration_min: '' });
+  const [addForm, setAddForm] = useState<PlanSessionFormState>({
+    title: '',
+    planned_start: '',
+    planned_duration_min: '',
+    notes: '',
+    reminder_enabled: true,
+    reminder_offset_min: '10',
+  });
   const [addFormSaving, setAddFormSaving] = useState(false);
 
   // When user taps "Done" on a chip, open LogActionModal pre-filled with the session data.
@@ -223,11 +284,21 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
     try {
       const created = await apiClient.createPlanSession(id, {
         title: addForm.title || undefined,
-        planned_start: addForm.planned_start || undefined,
+        planned_start: datetimeLocalToIso(addForm.planned_start),
         planned_duration_min: addForm.planned_duration_min ? Number(addForm.planned_duration_min) : undefined,
+        notes: addForm.notes || undefined,
+        reminder_enabled: addForm.reminder_enabled,
+        reminder_offset_min: Number(addForm.reminder_offset_min),
       });
       setPlanSessions(prev => [...prev, created]);
-      setAddForm({ title: '', planned_start: '', planned_duration_min: '' });
+      setAddForm({
+        title: '',
+        planned_start: '',
+        planned_duration_min: '',
+        notes: '',
+        reminder_enabled: true,
+        reminder_offset_min: '10',
+      });
       setShowAddForm(false);
       setActiveDurationPicker(null);
     } catch { /* ignore */ } finally {
@@ -236,14 +307,7 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
   };
 
   const getDefaultPlannedStart = () => {
-    const now = new Date();
-    const todayKey = formatDateTimeLocal(now).slice(0, 10);
-    if (weekDays.includes(todayKey)) {
-      return formatDateTimeLocal(roundUpToNextQuarterHour(now));
-    }
-
-    const firstWeekDay = weekDays[0] || todayKey;
-    return `${firstWeekDay}T09:00`;
+    return formatDateTimeLocal(roundUpToNextQuarterHour(new Date()));
   };
 
   const openAddSessionForm = () => {
@@ -251,6 +315,9 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
       title: '',
       planned_start: getDefaultPlannedStart(),
       planned_duration_min: '25',
+      notes: '',
+      reminder_enabled: true,
+      reminder_offset_min: '10',
     });
     setShowAddForm(true);
     setExpandedChipId(null);
@@ -259,7 +326,14 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
 
   const cancelAddSessionForm = () => {
     setShowAddForm(false);
-    setAddForm({ title: '', planned_start: '', planned_duration_min: '' });
+    setAddForm({
+      title: '',
+      planned_start: '',
+      planned_duration_min: '',
+      notes: '',
+      reminder_enabled: true,
+      reminder_offset_min: '10',
+    });
     setActiveDurationPicker(null);
   };
   
@@ -1071,8 +1145,12 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
       )}
 
       {/* Planned sessions strip — visible without expanding */}
-      {currentRecurring && (planSessions.filter(s => s.status === 'planned').length > 0 || showAddForm) && (
+      {(planSessions.filter(s => s.status === 'planned').length > 0 || showAddForm) && (
         <div className="planned-sessions-strip">
+          <div className="planned-sessions-strip-header">
+            <span>Planned sessions</span>
+            <span>{planSessions.filter(s => s.status === 'planned').length}</span>
+          </div>
           {planSessions.filter(s => s.status === 'planned').map(session => {
             const timeStr = session.planned_start
               ? new Date(session.planned_start).toLocaleString(undefined, {
@@ -1129,6 +1207,30 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
                       value={editForm.notes}
                       onChange={e => setEditForm(f => ({ ...f, notes: e.target.value }))}
                     />
+                    <div className="planned-session-quick-row">
+                      <button type="button" onClick={() => setEditForm(f => ({ ...f, planned_start: getDefaultPlannedStart() }))}>Today</button>
+                      <button type="button" onClick={() => setEditForm(f => ({ ...f, planned_start: shiftDateTimeLocal(f.planned_start, 60) }))}>+1h</button>
+                      <button type="button" onClick={() => setEditForm(f => ({ ...f, planned_start: shiftDateTimeLocal(f.planned_start, 1440) }))}>Tomorrow</button>
+                    </div>
+                    <div className="planned-session-reminder-row">
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={editForm.reminder_enabled}
+                          onChange={e => setEditForm(f => ({ ...f, reminder_enabled: e.target.checked }))}
+                        />
+                        Reminder
+                      </label>
+                      <select
+                        value={editForm.reminder_offset_min}
+                        disabled={!editForm.reminder_enabled}
+                        onChange={e => setEditForm(f => ({ ...f, reminder_offset_min: e.target.value }))}
+                      >
+                        {REMINDER_OFFSET_OPTIONS.map(option => (
+                          <option key={option.value} value={option.value}>{option.label}</option>
+                        ))}
+                      </select>
+                    </div>
                     <div className="planned-session-add-actions">
                       <button type="submit" className="planned-session-action planned-session-action--done" disabled={editFormSaving}>
                         {editFormSaving ? '…' : 'Save'}
@@ -1150,6 +1252,7 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
                       {session.planned_duration_min && (
                         <span className="planned-session-dur">{session.planned_duration_min}m</span>
                       )}
+                      <span className="planned-session-reminder">{reminderLabel(session)}</span>
                     </button>
                     {isOpen && (
                       <div className="planned-session-actions">
@@ -1219,6 +1322,37 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
                   )}
                 </div>
               </div>
+              <div className="planned-session-quick-row">
+                <button type="button" onClick={() => setAddForm(f => ({ ...f, planned_start: getDefaultPlannedStart() }))}>Today</button>
+                <button type="button" onClick={() => setAddForm(f => ({ ...f, planned_start: shiftDateTimeLocal(f.planned_start, 60) }))}>+1h</button>
+                <button type="button" onClick={() => setAddForm(f => ({ ...f, planned_start: shiftDateTimeLocal(f.planned_start, 1440) }))}>Tomorrow</button>
+              </div>
+              <textarea
+                className="planned-session-add-input planned-session-add-title"
+                placeholder="Notes (optional)"
+                value={addForm.notes}
+                onChange={e => setAddForm(f => ({ ...f, notes: e.target.value }))}
+                rows={2}
+              />
+              <div className="planned-session-reminder-row">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={addForm.reminder_enabled}
+                    onChange={e => setAddForm(f => ({ ...f, reminder_enabled: e.target.checked }))}
+                  />
+                  Reminder
+                </label>
+                <select
+                  value={addForm.reminder_offset_min}
+                  disabled={!addForm.reminder_enabled}
+                  onChange={e => setAddForm(f => ({ ...f, reminder_offset_min: e.target.value }))}
+                >
+                  {REMINDER_OFFSET_OPTIONS.map(option => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              </div>
               <div className="planned-session-add-actions">
                 <button type="submit" className="planned-session-action planned-session-action--done" disabled={addFormSaving}>
                   {addFormSaving ? '…' : 'Save'}
@@ -1257,15 +1391,13 @@ export function PromiseCard({ id, data, weekDays, onRefresh }: PromiseCardProps)
             + Log Time
           </button>
         )}
-        {currentRecurring && (
-          <button
-            className="card-add-session-button"
-            onClick={openAddSessionForm}
-            title="Add planned session"
-          >
-            + Add Session
-          </button>
-        )}
+        <button
+          className="card-add-session-button"
+          onClick={openAddSessionForm}
+          title="Add planned session"
+        >
+          + Add Session
+        </button>
         {isBudget && (
           <div className="budget-bar-container">
             <div className="budget-bar">

--- a/webapp_frontend/src/components/sheets/ScheduleSheet.tsx
+++ b/webapp_frontend/src/components/sheets/ScheduleSheet.tsx
@@ -13,6 +13,22 @@ interface ScheduleSheetProps {
 }
 
 const TIME_SLOTS = ['09:00', '12:00', '15:00', '18:00'];
+const REMINDER_OPTIONS = [
+  { value: 0, label: 'At start' },
+  { value: 5, label: '5m before' },
+  { value: 10, label: '10m before' },
+  { value: 30, label: '30m before' },
+  { value: 60, label: '1h before' },
+];
+
+function todayKey() {
+  const now = new Date();
+  return [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+  ].join('-');
+}
 
 function formatDayLabel(dateKey: string) {
   const date = new Date(`${dateKey}T12:00:00`);
@@ -23,30 +39,37 @@ function formatDayLabel(dateKey: string) {
 }
 
 export function ScheduleSheet({ open, promiseId, promiseText, weekDays, onClose, onSuccess }: ScheduleSheetProps) {
-  const [selectedDay, setSelectedDay] = useState(0);
+  const [selectedDate, setSelectedDate] = useState(todayKey());
   const [selectedTime, setSelectedTime] = useState('09:00');
+  const [reminderEnabled, setReminderEnabled] = useState(true);
+  const [reminderOffset, setReminderOffset] = useState('10');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
 
-  const labels = useMemo(() => weekDays.map(formatDayLabel), [weekDays]);
+  const selectableWeekDays = useMemo(() => weekDays.filter(day => day >= todayKey()), [weekDays]);
+  const labels = useMemo(() => selectableWeekDays.map(formatDayLabel), [selectableWeekDays]);
 
   useEffect(() => {
     if (!open) return;
-    setSelectedDay(0);
+    setSelectedDate(todayKey());
     setSelectedTime('09:00');
+    setReminderEnabled(true);
+    setReminderOffset('10');
     setError('');
   }, [open]);
 
   const handleSubmit = async () => {
-    if (!weekDays[selectedDay]) return;
+    if (!selectedDate || !selectedTime) return;
     setIsSubmitting(true);
     setError('');
     try {
-      const plannedStart = `${weekDays[selectedDay]}T${selectedTime}:00`;
+      const plannedStart = new Date(`${selectedDate}T${selectedTime}:00`).toISOString();
       await apiClient.createPlanSession(promiseId, {
         title: 'Planned session',
         planned_start: plannedStart,
         planned_duration_min: 25,
+        reminder_enabled: reminderEnabled,
+        reminder_offset_min: Number(reminderOffset),
       });
       onSuccess('Session scheduled');
       onClose();
@@ -59,20 +82,55 @@ export function ScheduleSheet({ open, promiseId, promiseText, weekDays, onClose,
 
   return (
     <BottomSheet open={open} onClose={onClose} title="Schedule session" subtitle={promiseText}>
-      <p className="ds-caption">Pick a day</p>
-      <div className="sched-grid">
+      <p className="ds-caption">Date and time</p>
+      <div className="sched-datetime-row">
+        <input
+          type="date"
+          value={selectedDate}
+          min={todayKey()}
+          onChange={(event) => setSelectedDate(event.target.value)}
+        />
+        <input
+          type="time"
+          value={selectedTime}
+          onChange={(event) => setSelectedTime(event.target.value)}
+        />
+      </div>
+      <div className="sched-shortcuts">
+        <button type="button" onClick={() => setSelectedDate(todayKey())}>Today</button>
+        <button
+          type="button"
+          onClick={() => {
+            const tomorrow = new Date();
+            tomorrow.setDate(tomorrow.getDate() + 1);
+            setSelectedDate([
+              tomorrow.getFullYear(),
+              String(tomorrow.getMonth() + 1).padStart(2, '0'),
+              String(tomorrow.getDate()).padStart(2, '0'),
+            ].join('-'));
+          }}
+        >
+          Tomorrow
+        </button>
+      </div>
+      {labels.length > 0 ? (
+        <>
+          <p className="ds-caption" style={{ marginTop: 12 }}>This week</p>
+          <div className="sched-grid">
         {labels.map((label, index) => (
           <button
-            key={weekDays[index]}
+            key={selectableWeekDays[index]}
             type="button"
-            className={`sched-day${selectedDay === index ? ' is-active' : ''}`}
-            onClick={() => setSelectedDay(index)}
+            className={`sched-day${selectedDate === selectableWeekDays[index] ? ' is-active' : ''}`}
+            onClick={() => setSelectedDate(selectableWeekDays[index])}
           >
             <span>{label.dow}</span>
             <span className="num">{label.num}</span>
           </button>
         ))}
-      </div>
+          </div>
+        </>
+      ) : null}
       <p className="ds-caption" style={{ marginTop: 12 }}>Pick a time</p>
       <div className="time-row">
         {TIME_SLOTS.map((slot) => (
@@ -85,6 +143,25 @@ export function ScheduleSheet({ open, promiseId, promiseText, weekDays, onClose,
             {slot}
           </button>
         ))}
+      </div>
+      <div className="sched-reminder-row">
+        <label>
+          <input
+            type="checkbox"
+            checked={reminderEnabled}
+            onChange={(event) => setReminderEnabled(event.target.checked)}
+          />
+          Reminder
+        </label>
+        <select
+          value={reminderOffset}
+          disabled={!reminderEnabled}
+          onChange={(event) => setReminderOffset(event.target.value)}
+        >
+          {REMINDER_OPTIONS.map(option => (
+            <option key={option.value} value={option.value}>{option.label}</option>
+          ))}
+        </select>
       </div>
       {error ? <p className="ds-caption" style={{ color: 'var(--bad-500)', marginTop: 8 }}>{error}</p> : null}
       <Button variant="primary" fullWidth onClick={handleSubmit} disabled={isSubmitting} style={{ marginTop: 16 }}>

--- a/webapp_frontend/src/styles/index.css
+++ b/webapp_frontend/src/styles/index.css
@@ -6999,7 +6999,20 @@ textarea.modal-input {
   margin-top: 8px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(232, 238, 252, 0.08);
+}
+
+.planned-sessions-strip-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
 
 .planned-session-entry {
@@ -7061,6 +7074,17 @@ textarea.modal-input {
   font-weight: 700;
   color: var(--accent);
   background: rgba(99, 167, 247, 0.12);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+.planned-session-reminder {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  color: #f8d06b;
+  background: rgba(248, 208, 107, 0.11);
+  border: 1px solid rgba(248, 208, 107, 0.2);
   border-radius: 4px;
   padding: 1px 5px;
 }
@@ -7143,6 +7167,11 @@ textarea.modal-input {
   grid-column: 1 / -1;
 }
 
+.planned-session-add-form textarea.planned-session-add-title {
+  min-height: 54px;
+  resize: vertical;
+}
+
 .planned-session-add-date {
   box-sizing: border-box;
   min-width: 0;
@@ -7198,6 +7227,48 @@ textarea.modal-input {
 .planned-session-duration-popover .wheel-picker-container {
   margin: 0;
   max-width: none;
+}
+
+.planned-session-quick-row,
+.planned-session-reminder-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.planned-session-quick-row button,
+.planned-session-reminder-row select {
+  min-height: 28px;
+  border: 1px solid rgba(232, 238, 252, 0.16);
+  border-radius: 4px;
+  background: rgba(232, 238, 252, 0.06);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 700;
+  font-family: inherit;
+}
+
+.planned-session-quick-row button {
+  padding: 0 9px;
+  cursor: pointer;
+}
+
+.planned-session-reminder-row {
+  justify-content: space-between;
+}
+
+.planned-session-reminder-row label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.planned-session-reminder-row select {
+  padding: 0 8px;
 }
 
 .planned-session-add-actions {

--- a/webapp_frontend/src/styles/sheets.css
+++ b/webapp_frontend/src/styles/sheets.css
@@ -886,6 +886,51 @@
 }
 
 .sched-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px; }
+.sched-datetime-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 120px;
+  gap: 8px;
+  margin-top: 8px;
+}
+.sched-datetime-row input,
+.sched-reminder-row select {
+  min-height: 40px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--fg);
+  padding: 0 10px;
+  font: inherit;
+}
+.sched-shortcuts,
+.sched-reminder-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+.sched-shortcuts button {
+  min-height: 30px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--fg);
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.sched-reminder-row {
+  justify-content: space-between;
+}
+.sched-reminder-row label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 700;
+}
 .sched-day {
   height: 56px;
   border: 1px solid var(--border);

--- a/webapp_frontend/src/types.ts
+++ b/webapp_frontend/src/types.ts
@@ -709,6 +709,8 @@ export interface PlanSession {
   planned_duration_min: number | null;
   notes: string | null;
   created_at: string;
+  reminder_enabled: boolean;
+  reminder_offset_min: number;
   checklist: PlanChecklistItem[];
 }
 
@@ -717,6 +719,8 @@ export interface PlanSessionIn {
   planned_start?: string;
   planned_duration_min?: number;
   notes?: string;
+  reminder_enabled?: boolean;
+  reminder_offset_min?: number;
   checklist?: Array<{ text: string; done?: boolean; position?: number }>;
 }
 


### PR DESCRIPTION
## Summary
- Fixes #75 by dispatching Telegram reminders for planned sessions before their start time through the bot scheduler.
- Addresses #74 by showing planned sessions directly on promise cards and improving the schedule-session UI with date/time inputs, shortcuts, and reminder controls.
- Adds reminder preference fields (`reminder_enabled`, `reminder_offset_min`) with an Alembic migration and API/frontend type support.

## Validation
- `python -m py_compile tm_bot\repositories\plan_sessions_repo.py tm_bot\services\plan_session_reminder_service.py tm_bot\webapp\routers\plan_sessions.py tm_bot\webapp\notifications.py tm_bot\handlers\callback_handlers.py tm_bot\planner_bot.py tm_bot\services\planner_api_adapter.py`
- `python -m pytest tests\unit\test_plan_session_reminder_service.py`
- `npm run build`
- `git diff --check`

## Notes
- The webapp planned-session sweeper is now gated behind `WEBAPP_PLAN_SESSION_REMINDER_SWEEPER=1`; the Telegram bot scheduler is the primary dispatcher to avoid duplicate reminder messages.