### PR TITLE
fix(sessions): calendar DM + titles (2026-05-31)

### DIFF
--- a/tests/unit/test_calendar_utils.py
+++ b/tests/unit/test_calendar_utils.py
@@ -1,7 +1,28 @@
 import pytest
 from datetime import datetime, timezone, timedelta
 
-from utils.calendar_utils import generate_google_calendar_link, generate_ics, suggest_time_slot
+from utils.calendar_utils import (
+    calendar_event_description,
+    generate_google_calendar_link,
+    generate_ics,
+    resolve_calendar_event_title,
+    suggest_time_slot,
+)
+
+
+@pytest.mark.unit
+def test_resolve_calendar_event_title_combines_promise_and_session():
+    assert resolve_calendar_event_title("Planned session", "Study_English") == "Study English — Session"
+    assert resolve_calendar_event_title("", "Morning_Run") == "Morning Run — Session"
+    assert resolve_calendar_event_title("Read ch. 3", "Study_English") == "Study English — Read ch. 3"
+    assert resolve_calendar_event_title("Read ch. 3", "") == "Read ch. 3"
+
+
+@pytest.mark.unit
+def test_calendar_event_description_skips_redundant_promise_line():
+    desc = calendar_event_description("Study English — Session", "Study_English")
+    assert "Xaana promise" not in desc
+    assert "xaana.club" in desc
 
 
 @pytest.mark.unit
@@ -17,6 +38,21 @@ def test_generate_google_calendar_link_naive_datetime_uses_zulu_suffix():
     assert "calendar.google.com/calendar/render" in url
     assert "text=Test" in url
     assert "dates=20250102T030405Z/20250102T040405Z" in url
+
+
+@pytest.mark.unit
+def test_generate_google_calendar_link_uses_promise_title_not_placeholder():
+    start = datetime(2026, 5, 31, 13, 0, 0, tzinfo=timezone.utc)
+    event_title = resolve_calendar_event_title("Planned session", "Study_English")
+    url = generate_google_calendar_link(
+        title=event_title,
+        start_time=start,
+        duration_hours=0.25,
+        description=calendar_event_description(event_title, "Study_English"),
+    )
+    assert "Study" in url and "English" in url
+    assert "Session" in url or "Session" in event_title
+    assert "Planned" not in url
 
 
 @pytest.mark.unit

--- a/tm_bot/handlers/callback_handlers.py
+++ b/tm_bot/handlers/callback_handlers.py
@@ -468,6 +468,9 @@ class CallbackHandlers:
             plan_session_id = cb.get("sid")
             status = "done" if action == "psess_done" else "skipped"
             await self._handle_plan_session_status(query, plan_session_id, status, user_lang)
+        elif action == "psess_ics":
+            plan_session_id = cb.get("sid")
+            await self._handle_plan_session_ics(query, plan_session_id, user_lang)
         elif action == "club_cancel":
             await self._handle_club_cancel(query, cb.get("cid"), user_lang)
         elif action == "club_remind":
@@ -1077,6 +1080,75 @@ class CallbackHandlers:
         except Exception as e:
             logger.error(f"Failed to delete plan_session {plan_session_id}: {e}")
             await query.answer("Failed to delete. Please try from the app.", show_alert=True)
+
+    async def _handle_plan_session_ics(self, query, plan_session_id: str, user_lang: Language):
+        """Send a .ics file for a planned session when the user taps ICS in the saved-session DM."""
+        from datetime import datetime, timezone
+        from io import BytesIO
+        from telegram import Bot, InputFile
+        from utils.calendar_utils import (
+            calendar_event_description,
+            generate_ics,
+            resolve_calendar_event_title,
+        )
+        from db.postgres_db import get_db_session
+        from sqlalchemy import text as sql_text
+
+        user_id = query.from_user.id
+        try:
+            plan = self.plan_keeper.plan_sessions_repo.get(int(plan_session_id), user_id)
+            if not plan or not plan.get("planned_start"):
+                if query.message:
+                    await query.message.reply_text("Session not found.")
+                return
+
+            promise_text = ""
+            p_uuid = plan.get("promise_uuid") or ""
+            if p_uuid:
+                with get_db_session() as session:
+                    row = session.execute(
+                        sql_text("SELECT text FROM promises WHERE promise_uuid = :uuid LIMIT 1"),
+                        {"uuid": p_uuid},
+                    ).fetchone()
+                promise_text = (row[0] if row else "") or ""
+            start_dt = datetime.fromisoformat(
+                str(plan["planned_start"]).replace("Z", "+00:00")
+            )
+            if start_dt.tzinfo is None:
+                start_dt = start_dt.replace(tzinfo=timezone.utc)
+
+            duration_min = int(plan.get("planned_duration_min") or 30)
+            event_title = resolve_calendar_event_title(plan.get("title"), promise_text)
+            description = calendar_event_description(
+                event_title, promise_text, plan.get("notes")
+            )
+            reminder_enabled = bool(plan.get("reminder_enabled", True))
+            offset = int(plan.get("reminder_offset_min") or 10)
+            ics_text = generate_ics(
+                title=event_title,
+                start_time=start_dt,
+                duration_hours=duration_min / 60.0,
+                description=description,
+                reminder_minutes_before=offset if reminder_enabled else None,
+            )
+
+            bot_token = self.application.bot.token if self.application and self.application.bot else None
+            if not bot_token:
+                if query.message:
+                    await query.message.reply_text("Could not send calendar file. Try again from the app.")
+                return
+
+            bot = Bot(token=bot_token)
+            ics_bytes = BytesIO(ics_text.encode("utf-8"))
+            await bot.send_document(
+                chat_id=user_id,
+                document=InputFile(ics_bytes, filename="xaana-session.ics"),
+                caption="Tap to add to your phone's calendar",
+            )
+        except Exception as e:
+            logger.error("Failed to send plan_session ICS for %s: %s", plan_session_id, e)
+            if query.message:
+                await query.message.reply_text("Could not send calendar file. Try from the app.")
 
     async def _handle_plan_session_status(self, query, plan_session_id: str, status: str, user_lang: Language):
         """Handle marking a planned session done or skipped from the reminder."""

--- a/tm_bot/utils/calendar_utils.py
+++ b/tm_bot/utils/calendar_utils.py
@@ -5,6 +5,59 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 from typing import Optional
 
+# Frontend default when the user leaves the title blank.
+_GENERIC_SESSION_TITLES = frozenset({"", "planned session", "focus session", "session"})
+
+
+def _humanize_promise_label(promise_text: Optional[str]) -> str:
+    return (promise_text or "").strip().replace("_", " ")
+
+
+def _session_label_for_calendar(title: Optional[str]) -> str:
+    """Session name for calendar titles; generic placeholders become a short default."""
+    raw = (title or "").strip()
+    if not raw or raw.lower() in _GENERIC_SESSION_TITLES:
+        return "Session"
+    return raw
+
+
+def resolve_calendar_event_title(title: Optional[str], promise_text: Optional[str]) -> str:
+    """
+    Calendar event title: promise name + session name.
+
+    Example: Study_English + "Read ch. 3" → "Study English — Read ch. 3".
+    When the stored session title is the app default ("Planned session"), the session
+    part becomes "Session" so the title is still two-part: "Study English — Session".
+    """
+    promise_display = _humanize_promise_label(promise_text)
+    session_display = _session_label_for_calendar(title)
+
+    if promise_display and session_display:
+        return f"{promise_display} — {session_display}"
+    if promise_display:
+        return promise_display
+    if session_display and session_display != "Session":
+        return session_display
+    return session_display or "Focus session"
+
+
+def calendar_event_description(
+    event_title: str,
+    promise_text: Optional[str],
+    notes: Optional[str] = None,
+) -> str:
+    """Build a Google Calendar / ICS description line."""
+    parts: list[str] = []
+    if notes and str(notes).strip():
+        parts.append(str(notes).strip())
+    promise_display = _humanize_promise_label(promise_text)
+    # Title already embeds the promise when we use resolve_calendar_event_title().
+    if promise_display and promise_display.lower() not in event_title.strip().lower():
+        parts.append(f"Xaana promise: {promise_display}")
+    if not parts:
+        parts.append("Scheduled with Xaana (xaana.club)")
+    return "\n".join(parts)
+
 
 def generate_google_calendar_link(
     title: str,

--- a/tm_bot/webapp/notifications.py
+++ b/tm_bot/webapp/notifications.py
@@ -7,12 +7,17 @@ import html
 from io import BytesIO
 from datetime import datetime, timezone
 from typing import Optional
-from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputFile
+from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputFile, WebAppInfo
 from telegram.error import BadRequest, TelegramError
 from telegram.helpers import escape_markdown
 from repositories.settings_repo import SettingsRepository
 from utils.admin_utils import get_admin_ids
-from utils.calendar_utils import generate_google_calendar_link, generate_ics
+from utils.calendar_utils import (
+    calendar_event_description,
+    generate_google_calendar_link,
+    generate_ics,
+    resolve_calendar_event_title,
+)
 from utils.logger import get_logger
 from cbdata import encode_cb, encode_session_cb
 
@@ -661,6 +666,8 @@ async def send_plan_session_reminder(
 async def send_plan_session_saved_notification(
     bot_token: str,
     user_id: int,
+    plan_session_id: int,
+    promise_id: str,
     promise_text: str,
     title: Optional[str],
     planned_start: Optional[str],
@@ -668,11 +675,14 @@ async def send_plan_session_saved_notification(
     reminder_enabled: bool = True,
     reminder_offset_min: int = 10,
     is_edit: bool = False,
+    miniapp_url: str = "https://xaana.club",
+    notes: Optional[str] = None,
 ) -> None:
     """
-    DM the user after they schedule/edit a session in the mini-app, offering
-    one-tap "add to calendar" options: a Google Calendar button plus an
-    attached .ics file (which opens the native add-to-calendar sheet on phones).
+    DM the user after they schedule/edit a session in the mini-app.
+
+    One message with: open promise in the app, Google Calendar link, and an
+    on-demand ICS button (sends the .ics file when tapped).
 
     Sending is best-effort — failures never block the API call that triggered it.
     """
@@ -691,22 +701,14 @@ async def send_plan_session_saved_notification(
 
         duration_min = int(planned_duration_min or 30)
         duration_hours = duration_min / 60.0
-        event_title = (title or promise_text or "Focus session").strip()
-        description = f"Xaana promise: {promise_text}".strip() if promise_text else ""
+        event_title = resolve_calendar_event_title(title, promise_text)
+        description = calendar_event_description(event_title, promise_text, notes)
 
-        # Build calendar artifacts (UTC times; calendar apps localize them).
         google_url = generate_google_calendar_link(
             title=event_title,
             start_time=start_dt,
             duration_hours=duration_hours,
             description=description,
-        )
-        ics_text = generate_ics(
-            title=event_title,
-            start_time=start_dt,
-            duration_hours=duration_hours,
-            description=description,
-            reminder_minutes_before=reminder_offset_min if reminder_enabled else None,
         )
 
         # Friendly local-time label using the user's timezone.
@@ -729,15 +731,30 @@ async def send_plan_session_saved_notification(
         lines = [f"📅 Session {verb}: {event_title}"]
         if when_label:
             lines.append(f"{when_label}  ·  {dur_label}")
-        promise_clean = (promise_text or "").strip()
-        if promise_clean and promise_clean != event_title:
+        promise_clean = (promise_text or "").strip().replace("_", " ")
+        if promise_clean and promise_clean.lower() != event_title.lower():
             lines.append(f"Promise: {promise_clean}")
-        lines.append("")
-        lines.append("Add it to your calendar 👇")
         message = "\n".join(lines)
 
+        app_base = (miniapp_url or "https://xaana.club").rstrip("/")
+        app_url = f"{app_base}/dashboard"
+        if promise_id:
+            app_url = f"{app_url}?promise={promise_id}"
+
         keyboard = InlineKeyboardMarkup([
-            [InlineKeyboardButton("📅 Add to Google Calendar", url=google_url)]
+            [
+                InlineKeyboardButton(
+                    "📱 See session in app",
+                    web_app=WebAppInfo(url=app_url),
+                )
+            ],
+            [
+                InlineKeyboardButton("📅 Google Calendar", url=google_url),
+                InlineKeyboardButton(
+                    "📎 ICS file",
+                    callback_data=encode_cb("psess_ics", sid=str(plan_session_id)),
+                ),
+            ],
         ])
 
         bot = Bot(token=bot_token)
@@ -747,16 +764,6 @@ async def send_plan_session_saved_notification(
             reply_markup=keyboard,
             parse_mode=None,
         )
-        # The .ics attachment opens the native "add to calendar" sheet on mobile.
-        try:
-            ics_bytes = BytesIO(ics_text.encode("utf-8"))
-            await bot.send_document(
-                chat_id=user_id,
-                document=InputFile(ics_bytes, filename="xaana-session.ics"),
-                caption="Tap to add to your phone's calendar",
-            )
-        except TelegramError as e:
-            logger.warning("Could not send .ics attachment to user %s: %s", user_id, e)
 
         logger.info("✓ Sent session-saved calendar DM to user %s", user_id)
     except TelegramError as e:

--- a/tm_bot/webapp/routers/plan_sessions.py
+++ b/tm_bot/webapp/routers/plan_sessions.py
@@ -3,6 +3,7 @@ Plan session endpoints: Promise → PlanSessions → Checklist.
 """
 
 import asyncio
+import os
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
@@ -26,19 +27,28 @@ router = APIRouter(prefix="/api", tags=["plan_sessions"])
 logger = get_logger(__name__)
 
 
-def _promise_text_for_uuid(promise_uuid: str) -> str:
-    """Look up a promise's text by its internal uuid (for calendar event titles)."""
+def _promise_row_for_uuid(promise_uuid: str) -> tuple[str, str]:
+    """Look up promise text and user-facing current_id by internal uuid."""
     if not promise_uuid:
-        return ""
+        return "", ""
     try:
         with get_db_session() as session:
             row = session.execute(
-                text("SELECT text FROM promises WHERE promise_uuid = :uuid"),
+                text(
+                    "SELECT text, current_id FROM promises WHERE promise_uuid = :uuid LIMIT 1"
+                ),
                 {"uuid": promise_uuid},
             ).fetchone()
-        return (row[0] if row else "") or ""
+        if not row:
+            return "", ""
+        return (row[0] or "") or "", (row[1] or "") or ""
     except Exception:
-        return ""
+        return "", ""
+
+
+def _promise_text_for_uuid(promise_uuid: str) -> str:
+    text_value, _ = _promise_row_for_uuid(promise_uuid)
+    return text_value
 
 
 def _fire_session_saved_dm(
@@ -57,7 +67,8 @@ def _fire_session_saved_dm(
         bot_token = getattr(request.app.state, "bot_token", None)
         if not bot_token:
             return
-        promise_text = _promise_text_for_uuid(session_row.get("promise_uuid"))
+        promise_text, promise_id = _promise_row_for_uuid(session_row.get("promise_uuid"))
+        miniapp_url = os.getenv("MINIAPP_URL", "https://xaana.club")
 
         from ..notifications import send_plan_session_saved_notification
 
@@ -65,13 +76,17 @@ def _fire_session_saved_dm(
             send_plan_session_saved_notification(
                 bot_token=bot_token,
                 user_id=user_id,
+                plan_session_id=int(session_row["id"]),
+                promise_id=promise_id,
                 promise_text=promise_text,
                 title=session_row.get("title"),
+                notes=session_row.get("notes"),
                 planned_start=session_row.get("planned_start"),
                 planned_duration_min=session_row.get("planned_duration_min"),
                 reminder_enabled=bool(session_row.get("reminder_enabled", True)),
                 reminder_offset_min=int(session_row.get("reminder_offset_min") or 10),
                 is_edit=is_edit,
+                miniapp_url=miniapp_url,
             )
         )
     except Exception as e:

--- a/webapp_frontend/src/pages/DashboardPage.tsx
+++ b/webapp_frontend/src/pages/DashboardPage.tsx
@@ -423,6 +423,20 @@ export function DashboardPage() {
     setDetailPromise({ id, data });
   }, []);
 
+  // Deep link from Telegram DM: /dashboard?promise=<id> opens the promise detail sheet.
+  const openPromiseId = searchParams.get('promise');
+  useEffect(() => {
+    if (!openPromiseId || !reportData) return;
+    const promiseData =
+      reportData.promises[openPromiseId]
+      ?? olderPromisesData?.promises[openPromiseId];
+    if (!promiseData) return;
+    setDetailPromise({ id: openPromiseId, data: promiseData });
+    const next = new URLSearchParams(searchParams);
+    next.delete('promise');
+    setSearchParams(next, { replace: true });
+  }, [openPromiseId, reportData, olderPromisesData, searchParams, setSearchParams]);
+
   // Keep the open detail sheet in sync with refreshed report data, so logging
   // a session updates its badge/grids live instead of showing a stale snapshot.
   useEffect(() => {

--- a/webapp_frontend/src/utils/calendar.ts
+++ b/webapp_frontend/src/utils/calendar.ts
@@ -16,6 +16,41 @@ interface CalendarEvent {
 
 const DEFAULT_DURATION_MIN = 30;
 
+const GENERIC_SESSION_TITLES = new Set(['', 'planned session', 'focus session', 'session']);
+
+function humanizePromiseLabel(promiseText: string): string {
+  return (promiseText || '').trim().replace(/_/g, ' ');
+}
+
+function sessionLabelForCalendar(title: string | undefined | null): string {
+  const raw = (title || '').trim();
+  if (!raw || GENERIC_SESSION_TITLES.has(raw.toLowerCase())) return 'Session';
+  return raw;
+}
+
+/** Calendar title: promise name + session name (e.g. "Study English — Read ch. 3"). */
+export function resolveCalendarEventTitle(title: string | undefined | null, promiseText: string): string {
+  const promiseDisplay = humanizePromiseLabel(promiseText);
+  const sessionDisplay = sessionLabelForCalendar(title);
+  if (promiseDisplay && sessionDisplay) {
+    return `${promiseDisplay} — ${sessionDisplay}`;
+  }
+  if (promiseDisplay) return promiseDisplay;
+  if (sessionDisplay && sessionDisplay !== 'Session') return sessionDisplay;
+  return sessionDisplay || 'Focus session';
+}
+
+function calendarEventDescription(eventTitle: string, promiseText: string, notes?: string | null): string {
+  const parts: string[] = [];
+  if (notes?.trim()) parts.push(notes.trim());
+  const promiseDisplay = (promiseText || '').trim().replace(/_/g, ' ');
+  if (promiseDisplay && !eventTitle.toLowerCase().includes(promiseDisplay.toLowerCase())) {
+    parts.push(`Xaana promise: ${promiseDisplay}`);
+  }
+  if (!parts.length) parts.push('Scheduled with Xaana (xaana.club)');
+  return parts.join('\n');
+}
+
 /** Format a Date as a UTC stamp: YYYYMMDDTHHMMSSZ (RFC 5545 / Google format). */
 function utcStamp(date: Date): string {
   return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
@@ -26,12 +61,16 @@ function eventFromSession(session: PlanSession, promiseText: string): CalendarEv
   if (!session.planned_start) return null;
   const start = new Date(session.planned_start);
   if (Number.isNaN(start.getTime())) return null;
-  const title = (session.title || promiseText || 'Focus session').trim();
+  const title = resolveCalendarEventTitle(session.title, promiseText);
   const durationMin = session.planned_duration_min && session.planned_duration_min > 0
     ? session.planned_duration_min
     : DEFAULT_DURATION_MIN;
-  const descParts = [promiseText ? `Xaana promise: ${promiseText}` : '', session.notes || ''];
-  return { title, start, durationMin, description: descParts.filter(Boolean).join('\n') };
+  return {
+    title,
+    start,
+    durationMin,
+    description: calendarEventDescription(title, promiseText, session.notes),
+  };
 }
 
 /** Google Calendar "template" URL — opens a pre-filled event in Google Calendar. */


### PR DESCRIPTION
## Summary
- After scheduling/editing a plan session in the mini-app, Telegram sends **one** DM with: open promise in app (`/dashboard?promise=`), Google Calendar link, and on-demand ICS (button sends `.ics` when tapped).
- Calendar event titles use **promise + session** (e.g. `Study English — Read ch. 3`; default session title becomes `Study English — Session` instead of bare `Planned session`).
- Mini-app Add to calendar sheet uses the same title rules; dashboard deep-link opens `PromiseDetailSheet`.

## Test plan
- [ ] Create a session without custom title → one Telegram message, 3 buttons; Google `text=` shows `Promise — Session`
- [ ] Create with custom session title → Google title shows `Promise — Custom title`
- [ ] Tap **ICS file** → single `.ics` document, no auto-attach on create
- [ ] Tap **See session in app** → opens dashboard with promise detail sheet
- [ ] `pytest tests/unit/test_calendar_utils.py`
- [ ] `webapp_frontend`: `npm run build` (or `tsc --noEmit`)
