### PR TITLE
Promise recall + memory capture + one-time sessions (2026-05-31)

### DIFF
--- a/scripts/eval_promise_resolver_llm.py
+++ b/scripts/eval_promise_resolver_llm.py
@@ -1,0 +1,88 @@
+"""Recall eval of the NEW LLM promise resolver vs the substring baseline.
+
+Reuses the exact 92-query battery from eval_search_promises.py, but routes each query
+through resolve_promise_with_llm using the real router model. Prints the same metrics so
+the before/after is directly comparable.
+"""
+import os
+import sys
+import json
+from collections import defaultdict
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(HERE), "tm_bot"))
+sys.path.insert(0, HERE)
+
+from eval_search_promises import Q, PROMISES, expect_set  # noqa: E402
+from llms.resolvers import resolve_promise_with_llm  # noqa: E402
+from llms.llm_handler import LLMHandler  # noqa: E402
+
+
+def main():
+    handler = LLMHandler()
+    model = handler.router_model
+    promises = [{"id": i, "text": t} for i, t in PROMISES]
+
+    rows = []
+    for query, expect, cat in Q:
+        out = json.loads(resolve_promise_with_llm(model, query, promises))
+        conf = out.get("confidence")
+        resolved = out.get("resolved")
+        ids = set(out.get("candidates") or [])
+        if resolved:
+            ids.add(str(resolved))
+        rows.append({"q": query, "cat": cat, "expect": expect_set(expect), "conf": conf, "ids": ids})
+
+    targeted = [r for r in rows if r["expect"] is not None]
+    novel = [r for r in rows if r["expect"] is None]
+
+    def recall(r):
+        return bool(r["expect"] & r["ids"])
+
+    def clean(r):
+        return r["conf"] == "high" and bool(r["ids"] & r["expect"])
+
+    n_recall = sum(recall(r) for r in targeted)
+    n_clean = sum(clean(r) for r in targeted)
+    n_miss = sum(1 for r in targeted if not recall(r))
+    novel_ok = sum(1 for r in novel if r["conf"] == "none")
+    novel_false = len(novel) - novel_ok
+
+    def pct(a, b):
+        return f"{(100.0 * a / b):5.1f}%" if b else "  n/a"
+
+    print(f"\n{'='*60}")
+    print(f"LLM promise-resolver eval — {len(rows)} queries vs {len(PROMISES)} promises")
+    print(f"{'='*60}")
+    print(f"--- TARGETED (n={len(targeted)}) — a real promise exists ---")
+    print(f"  recall@any:            {pct(n_recall, len(targeted))}  ({n_recall}/{len(targeted)})   [substring baseline: 46.2%]")
+    print(f"  clean auto-resolve:    {pct(n_clean, len(targeted))}  ({n_clean}/{len(targeted)})   [baseline: 41.0%]")
+    print(f"  MISS:                  {pct(n_miss, len(targeted))}  ({n_miss}/{len(targeted)})   [baseline: 53.8%]")
+    print(f"\n--- NOVEL (n={len(novel)}) — want 'none' -> one-time promise ---")
+    print(f"  correct none:          {pct(novel_ok, len(novel))}  ({novel_ok}/{len(novel)})")
+    print(f"  WRONG match:           {pct(novel_false, len(novel))}  ({novel_false}/{len(novel)})")
+
+    cats = defaultdict(lambda: [0, 0])
+    for r in rows:
+        c = cats[r["cat"]]
+        c[0] += 1
+        c[1] += (r["conf"] == "none") if r["expect"] is None else recall(r)
+    print(f"\n--- by category (recall, or no-match for novel) ---")
+    for cat in ["exact", "ambiguous", "synonym", "typo", "phrase", "novel"]:
+        n, good = cats[cat]
+        print(f"  {cat:<11} {n:>3} {good:>3}  {pct(good, n)}")
+
+    print(f"\n--- remaining MISSES ---")
+    for r in targeted:
+        if not recall(r):
+            print(f"  [{r['cat']:<8}] {r['q']!r:<26} -> conf={r['conf']} {sorted(r['ids']) or ''} (wanted {sorted(r['expect'])})")
+    if novel_false:
+        print(f"\n--- NOVEL false-matches (would NOT create one-time promise) ---")
+        for r in novel:
+            if r["conf"] != "none":
+                print(f"  {r['q']!r:<26} -> conf={r['conf']} {sorted(r['ids'])}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_search_promises.py
+++ b/scripts/eval_search_promises.py
@@ -1,0 +1,197 @@
+"""Quantitative eval of search_promises against a realistic promise set.
+
+Drives the REAL adapter method (PlannerAPIAdapter.search_promises) offline via an
+in-memory fake repo, so there are no DB calls and no prod side effects. Queries are
+labeled by *human intent*; a synonym/typo that the substring matcher misses counts as
+a recall failure. Novel queries (no relevant promise) are scored as the DESIRED
+one-time-promise fallback path, not as failures.
+"""
+import os
+import re
+import sys
+import json
+import types
+from collections import defaultdict
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tm_bot"))
+from services.planner_api_adapter import PlannerAPIAdapter  # noqa: E402
+
+# --- Real promise set (user 108648163), texts exactly as stored ---
+PROMISES = [
+    ("C01", "Play_Cheenva"), ("C02", "Crossfit_and_Gym"), ("P01", "Deep_work_(Stage11)"),
+    ("P06", "Call_my_family"), ("P07", "Home_chores_/_Cooking"),
+    ("P08", "Practice_French/English_(Comprehension_Oral)"), ("P09", "Play_piano"),
+    ("P10", "Do_sport"), ("P11", "Exercise_back_and_neck_correction"),
+    ("P12", "Hair_&_skin_care"), ("P13", "Reading_books"), ("P16", "Next_One"),
+    ("P17", "Building_robots"), ("P18", "Work_on_Zana"), ("P19", "Forcapil_(for_hair)"),
+    ("P20", "Study_English"), ("P21", "buy_volleyball_tickets_for_Iran_vs_France_match"),
+    ("T02", "Talk_to_a_Mentor"),
+]
+
+def _mk(id_, text):
+    return types.SimpleNamespace(id=id_, text=text, hours_per_week=1.0, start_date=None, end_date=None)
+
+FAKE = types.SimpleNamespace(
+    promises_repo=types.SimpleNamespace(list_promises=lambda u: [_mk(i, t) for i, t in PROMISES]),
+    actions_repo=types.SimpleNamespace(list_actions=lambda u: []),
+)
+
+# --- Labeled query battery. expect: id | tuple(ids) | None(novel -> one-time) ---
+# cat: exact | ambiguous | synonym | typo | phrase | novel
+Q = [
+    # exact / substring (should resolve cleanly)
+    ("cooking", "P07", "exact"), ("cook", "P07", "exact"), ("chores", "P07", "exact"),
+    ("piano", "P09", "exact"), ("reading", "P13", "exact"), ("read", "P13", "exact"),
+    ("books", "P13", "exact"), ("family", "P06", "exact"), ("crossfit", "C02", "exact"),
+    ("gym", "C02", "exact"), ("zana", "P18", "exact"), ("mentor", "T02", "exact"),
+    ("volleyball", "P21", "exact"), ("tickets", "P21", "exact"), ("forcapil", "P19", "exact"),
+    ("cheenva", "C01", "exact"), ("robots", "P17", "exact"), ("robot", "P17", "exact"),
+    ("neck", "P11", "exact"), ("skin", "P12", "exact"), ("french", "P08", "exact"),
+    ("deep work", "P01", "exact"), ("study english", "P20", "exact"), ("do sport", "P10", "exact"),
+    ("building robots", "P17", "exact"), ("talk to a mentor", "T02", "exact"),
+    ("play piano", "P09", "exact"), ("call my family", "P06", "exact"),
+
+    # genuinely ambiguous (multiple valid targets)
+    ("play", ("C01", "P09"), "ambiguous"), ("english", ("P08", "P20"), "ambiguous"),
+    ("hair", ("P12", "P19"), "ambiguous"), ("work", ("P01", "P18"), "ambiguous"),
+
+    # synonyms / paraphrase (intent target; substring often misses -> recall test)
+    ("cuisine", "P07", "synonym"), ("meal prep", "P07", "synonym"),
+    ("tidy up", "P07", "synonym"), ("clean the house", "P07", "synonym"),
+    ("phone mom", "P06", "synonym"), ("parents", "P06", "synonym"),
+    ("call parents", "P06", "synonym"), ("novel", "P13", "synonym"),
+    ("book", "P13", "synonym"), ("language practice", ("P08", "P20"), "synonym"),
+    ("learn french", "P08", "synonym"), ("learn english", "P20", "synonym"),
+    ("coding", ("P17", "P18"), "synonym"), ("programming", ("P17", "P18"), "synonym"),
+    ("app development", "P18", "synonym"), ("haircare", "P12", "synonym"),
+    ("skincare", "P12", "synonym"), ("fitness", ("C02", "P10", "P11"), "synonym"),
+    ("workout", ("C02", "P10", "P11"), "synonym"), ("sport", ("C02", "P10", "P11"), "synonym"),
+    ("exercise", ("C02", "P10", "P11"), "synonym"), ("weightlifting", "C02", "synonym"),
+    ("mentorship", "T02", "synonym"), ("career advice", "T02", "synonym"),
+
+    # typos
+    ("cookng", "P07", "typo"), ("cokking", "P07", "typo"), ("robto", "P17", "typo"),
+    ("robos", "P17", "typo"), ("pian", "P09", "typo"), ("familly", "P06", "typo"),
+    ("vollyball", "P21", "typo"), ("crossft", "C02", "typo"), ("redaing", "P13", "typo"),
+    ("menter", "T02", "typo"), ("frnch", "P08", "typo"), ("pianno", "P09", "typo"),
+
+    # natural multiword phrases
+    ("cook tuna tonight", "P07", "phrase"), ("play the piano", "P09", "phrase"),
+    ("work on the app", "P18", "phrase"), ("call my mom", "P06", "phrase"),
+    ("go to the gym", "C02", "phrase"), ("read a book", "P13", "phrase"),
+    ("do some sport", "P10", "phrase"), ("talk to mentor", "T02", "phrase"),
+    ("build a robot", "P17", "phrase"), ("study french and english", ("P08", "P20"), "phrase"),
+
+    # novel -> should be no-match -> one-time promise fallback (DESIRED)
+    ("dentist appointment", None, "novel"), ("buy groceries", None, "novel"),
+    ("car insurance", None, "novel"), ("meditate", None, "novel"),
+    ("water the plants", None, "novel"), ("write a blog post", None, "novel"),
+    ("do taxes", None, "novel"), ("yoga", None, "novel"), ("swimming", None, "novel"),
+    ("clean the garage", None, "novel"), ("doctor visit", None, "novel"),
+    ("pay rent", None, "novel"), ("birthday gift", None, "novel"), ("learn guitar", None, "novel"),
+]
+
+
+def parse_search(out: str):
+    """Return (match_type, set_of_ids). match_type in {single, multi, none}."""
+    s = out.strip()
+    if s.startswith("{"):
+        try:
+            j = json.loads(s)
+            if j.get("single_match"):
+                return "single", {j.get("promise_id")}
+        except Exception:
+            pass
+    if s.startswith(("No promises found", "You don't have", "Please provide")):
+        return "none", set()
+    ids = set(re.findall(r"#([A-Za-z0-9]+)", s))
+    if ids:
+        return "multi", ids
+    return "none", set()
+
+
+def expect_set(expect):
+    if expect is None:
+        return None
+    return set(expect) if isinstance(expect, tuple) else {expect}
+
+
+def main():
+    rows = []
+    for query, expect, cat in Q:
+        out = PlannerAPIAdapter.search_promises(FAKE, 108648163, query)
+        mtype, ids = parse_search(out)
+        E = expect_set(expect)
+        rows.append({"q": query, "cat": cat, "expect": E, "mtype": mtype, "ids": ids})
+
+    total = len(rows)
+    targeted = [r for r in rows if r["expect"] is not None]
+    novel = [r for r in rows if r["expect"] is None]
+
+    def recall(r):  # target found at all
+        return bool(r["expect"] & r["ids"])
+
+    def clean_resolve(r):  # single auto-select to a correct target
+        return r["mtype"] == "single" and bool(r["ids"] & r["expect"])
+
+    n_recall = sum(recall(r) for r in targeted)
+    n_clean = sum(clean_resolve(r) for r in targeted)
+    n_multi_ok = sum(1 for r in targeted if r["mtype"] == "multi" and recall(r))
+    n_miss = sum(1 for r in targeted if not recall(r))
+
+    novel_correct = sum(1 for r in novel if r["mtype"] == "none")
+    novel_false_attach = sum(1 for r in novel if r["mtype"] != "none")
+
+    mtype_dist = defaultdict(int)
+    for r in rows:
+        mtype_dist[r["mtype"]] += 1
+
+    def pct(a, b):
+        return f"{(100.0 * a / b):5.1f}%" if b else "  n/a"
+
+    print(f"\n{'='*64}")
+    print(f"search_promises eval — {total} queries vs {len(PROMISES)} promises")
+    print(f"{'='*64}")
+    print(f"match-type distribution:  single={mtype_dist['single']}  "
+          f"multi={mtype_dist['multi']}  none={mtype_dist['none']}")
+
+    print(f"\n--- TARGETED queries (n={len(targeted)}): a real promise exists ---")
+    print(f"  recall@any (target found):      {pct(n_recall, len(targeted))}  ({n_recall}/{len(targeted)})")
+    print(f"  clean auto-resolve (single==target): {pct(n_clean, len(targeted))}  ({n_clean}/{len(targeted)})")
+    print(f"  found-but-needs-pick (multi):   {pct(n_multi_ok, len(targeted))}  ({n_multi_ok}/{len(targeted)})")
+    print(f"  MISS (target not found):        {pct(n_miss, len(targeted))}  ({n_miss}/{len(targeted)})")
+
+    print(f"\n--- NOVEL queries (n={len(novel)}): no promise -> want one-time fallback ---")
+    print(f"  correct no-match (-> one-time): {pct(novel_correct, len(novel))}  ({novel_correct}/{len(novel)})")
+    print(f"  WRONG attach (false match):     {pct(novel_false_attach, len(novel))}  ({novel_false_attach}/{len(novel)})")
+
+    print(f"\n--- by category ---")
+    cats = defaultdict(lambda: [0, 0, 0])  # [n, good, label-specific]
+    for r in rows:
+        c = cats[r["cat"]]
+        c[0] += 1
+        if r["expect"] is None:
+            c[1] += 1 if r["mtype"] == "none" else 0
+        else:
+            c[1] += 1 if recall(r) else 0
+    print(f"  {'category':<11} {'n':>3} {'good':>5}  rate")
+    for cat in ["exact", "ambiguous", "synonym", "typo", "phrase", "novel"]:
+        n, good, _ = cats[cat]
+        metric = "no-match" if cat == "novel" else "recall"
+        print(f"  {cat:<11} {n:>3} {good:>5}  {pct(good, n)}  ({metric})")
+
+    print(f"\n--- recall MISSES (targeted queries where the right promise was not found) ---")
+    for r in targeted:
+        if not recall(r):
+            print(f"  [{r['cat']:<8}] {r['q']!r:<28} -> {r['mtype']:<5} {sorted(r['ids']) or ''}  (wanted {sorted(r['expect'])})")
+
+    if novel_false_attach:
+        print(f"\n--- NOVEL false-attaches (would wrongly attach instead of one-time) ---")
+        for r in novel:
+            if r["mtype"] != "none":
+                print(f"  {r['q']!r:<28} -> {r['mtype']} {sorted(r['ids'])}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/handlers/test_one_time_confirmation.py
+++ b/tests/handlers/test_one_time_confirmation.py
@@ -1,0 +1,25 @@
+"""Handler tests for the 'track as one-time' confirmation button."""
+import pytest
+
+
+@pytest.mark.handler
+def test_confirmation_kb_adds_one_time_button_for_schedule_session():
+    pytest.importorskip("telegram")
+    pytest.importorskip("langgraph.prebuilt")
+    from handlers.message_handlers import MessageHandlers
+
+    mh = MessageHandlers.__new__(MessageHandlers)  # no __init__ side effects
+
+    kb = mh._mutation_confirmation_kb(None, {"tool_name": "schedule_session"})
+    buttons = [b for row in kb.inline_keyboard for b in row]
+    # Yes, Skip, and the extra one-time button.
+    assert len(buttons) == 3
+
+    kb2 = mh._mutation_confirmation_kb(None, {"tool_name": "log_completed_activity"})
+    buttons2 = [b for row in kb2.inline_keyboard for b in row]
+    assert len(buttons2) == 2  # only Yes / Skip
+
+    # No pending → safe default of Yes / Skip only.
+    kb3 = mh._mutation_confirmation_kb(None, None)
+    buttons3 = [b for row in kb3.inline_keyboard for b in row]
+    assert len(buttons3) == 2

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -211,10 +211,48 @@ def test_run_memory_flush_appends_to_date_file(monkeypatch, tmp_path):
         now_utc=datetime(2025, 2, 19, tzinfo=timezone.utc),
     )
     assert len(calls) == 1
-    assert "2025-02-19" in calls[0][1]
+    # The flush still writes to the date-named file (run_memory_flush owns the path).
     target = tmp_path / "42" / "memory" / "2025-02-19.md"
     assert target.exists()
     assert "User prefers morning standups" in target.read_text(encoding="utf-8")
+
+
+# ── turn-based flush trigger (chat-bot usage) ─────────────────────────────────
+
+
+@pytest.mark.unit
+def test_turn_trigger_fires_at_interval():
+    assert should_run_memory_flush(
+        entry={"message_count": 16, "flush_every_messages": 16, "memory_flush_message_count": 0}
+    ) is True
+
+
+@pytest.mark.unit
+def test_turn_trigger_below_interval_does_not_fire():
+    assert should_run_memory_flush(
+        entry={"message_count": 15, "flush_every_messages": 16, "memory_flush_message_count": 0}
+    ) is False
+
+
+@pytest.mark.unit
+def test_turn_trigger_dedups_until_next_interval():
+    # Already flushed at 16; at 20 (only +4) it should not fire again...
+    assert should_run_memory_flush(
+        entry={"message_count": 20, "flush_every_messages": 16, "memory_flush_message_count": 16}
+    ) is False
+    # ...but at 32 (+16 since last flush) it should.
+    assert should_run_memory_flush(
+        entry={"message_count": 32, "flush_every_messages": 16, "memory_flush_message_count": 16}
+    ) is True
+
+
+@pytest.mark.unit
+def test_turn_trigger_disabled_when_interval_zero():
+    # interval 0 → fall through to token logic; with a small history (< the legacy 50-msg
+    # proxy) and no token count, it stays under threshold.
+    assert should_run_memory_flush(
+        entry={"message_count": 30, "flush_every_messages": 0}
+    ) is False
 
 
 # ── memory_write ──────────────────────────────────────────────────────────────

--- a/tests/unit/test_one_time_label.py
+++ b/tests/unit/test_one_time_label.py
@@ -1,0 +1,32 @@
+"""Unit tests for the one-time promise label derivation (agent._one_time_label_from)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tm_bot"))
+from llms.agent import _one_time_label_from  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_prefers_session_title():
+    assert _one_time_label_from({"title": "Cook tuna"}, "rambly message ignored") == "Cook tuna"
+
+
+def test_title_truncated_to_60():
+    assert len(_one_time_label_from({"title": "x" * 100}, "")) == 60
+
+
+def test_extracts_i_want_to_phrase_when_no_title():
+    assert "read a book" in _one_time_label_from({}, "I want to read a book")
+
+
+def test_snippet_fallback_when_no_pattern():
+    out = _one_time_label_from({}, "okay i am going to cook something tonight for dinner")
+    assert out and len(out) <= 60 and out != "One-time session"
+
+
+def test_default_when_empty():
+    assert _one_time_label_from({}, "") == "One-time session"
+    assert _one_time_label_from({}, "   ") == "One-time session"

--- a/tests/unit/test_promise_resolver.py
+++ b/tests/unit/test_promise_resolver.py
@@ -1,0 +1,95 @@
+"""Unit tests for resolve_promise_with_llm (semantic promise matching).
+
+Uses a fake model so the tests are deterministic and offline.
+"""
+import json
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tm_bot"))
+from llms.resolvers import resolve_promise_with_llm  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+PROMISES = [
+    {"id": "P07", "text": "Home_chores_/_Cooking"},
+    {"id": "P08", "text": "Practice_French/English"},
+    {"id": "P09", "text": "Play_piano"},
+    {"id": "P20", "text": "Study_English"},
+]
+
+
+class FakeModel:
+    """Returns a fixed reply (str) for every invoke; or raises if reply is an Exception."""
+
+    def __init__(self, reply):
+        self._reply = reply
+
+    def invoke(self, messages):
+        if isinstance(self._reply, Exception):
+            raise self._reply
+        return types.SimpleNamespace(content=self._reply)
+
+
+def _resolve(reply, query="something", promises=PROMISES):
+    return json.loads(resolve_promise_with_llm(FakeModel(reply), query, promises))
+
+
+def test_high_confidence_valid_id_passes_through():
+    out = _resolve('{"resolved": "P07", "confidence": "high"}', "cook dinner")
+    assert out == {"resolved": "P07", "confidence": "high"}
+
+
+def test_high_confidence_unknown_id_is_demoted_to_none():
+    # Model hallucinates an id that isn't in the promise set.
+    out = _resolve('{"resolved": "P99", "confidence": "high"}')
+    assert out == {"resolved": None, "confidence": "none"}
+
+
+def test_low_confidence_keeps_only_valid_candidates():
+    out = _resolve(
+        '{"resolved": null, "confidence": "low", '
+        '"candidates": ["P08", "P20", "P99"], "clarification": "Which one?"}',
+        "english",
+    )
+    assert out["confidence"] == "low"
+    assert out["candidates"] == ["P08", "P20"]  # P99 filtered out
+    assert out["clarification"] == "Which one?"
+
+
+def test_low_confidence_with_no_valid_candidates_becomes_none():
+    out = _resolve('{"resolved": null, "confidence": "low", "candidates": ["P99"]}')
+    assert out == {"resolved": None, "confidence": "none"}
+
+
+def test_none_confidence_passes_through():
+    out = _resolve('{"resolved": null, "confidence": "none"}', "dentist appointment")
+    assert out == {"resolved": None, "confidence": "none"}
+
+
+def test_markdown_fenced_json_is_parsed():
+    out = _resolve('```json\n{"resolved": "P09", "confidence": "high"}\n```', "piano")
+    assert out == {"resolved": "P09", "confidence": "high"}
+
+
+def test_malformed_model_output_returns_none():
+    out = _resolve("not json at all")
+    assert out == {"resolved": None, "confidence": "none"}
+
+
+def test_model_exception_returns_none():
+    out = _resolve(RuntimeError("boom"))
+    assert out == {"resolved": None, "confidence": "none"}
+
+
+def test_empty_query_short_circuits_without_model_call():
+    out = _resolve('{"resolved": "P07", "confidence": "high"}', query="   ")
+    assert out == {"resolved": None, "confidence": "none"}
+
+
+def test_no_promises_short_circuits():
+    out = json.loads(resolve_promise_with_llm(FakeModel('{"resolved": "P07", "confidence": "high"}'), "cook", []))
+    assert out == {"resolved": None, "confidence": "none"}

--- a/tm_bot/handlers/callback_handlers.py
+++ b/tm_bot/handlers/callback_handlers.py
@@ -549,6 +549,7 @@ class CallbackHandlers:
         user_id = query.from_user.id
         decision = str((cb or {}).get("d", "")).strip().lower()
         is_confirm = decision in {"yes", "confirm", "y", "1", "true"}
+        is_one_time = decision == "one_time"
 
         pending = (context.user_data or {}).get("pending_clarification") if hasattr(context, "user_data") else None
         if not pending or str(pending.get("reason", "")).strip().lower() != "pre_mutation_confirmation":
@@ -578,7 +579,33 @@ class CallbackHandlers:
 
         # --- Execute or skip the current item ---
         _step_ok = True  # set to False only on unexpected tool error
-        if is_confirm:
+        if is_one_time and tool_name in ("schedule_session", "add_plan_session"):
+            # User opted to track the activity as its own one-time promise instead of
+            # attaching the session to the matched promise. Create a non-recurring promise,
+            # then schedule the session against it.
+            try:
+                label = str(pending.get("one_time_label") or tool_args.get("title") or "One-time task").strip()
+                create_ret = self.plan_keeper.add_promise(
+                    user_id=user_id,
+                    promise_text=label,
+                    num_hours_promised_per_week=0.0,
+                    recurring=False,
+                )
+                m = re.search(r"#([A-Za-z0-9]+)", str(create_ret or ""))
+                new_pid = m.group(1) if m else None
+                if not new_pid:
+                    raise RuntimeError(f"could not create one-time promise: {create_ret}")
+                sched_args = {k: v for k, v in (tool_args or {}).items() if k != "promise_id"}
+                sched_args["promise_id"] = new_pid
+                if not sched_args.get("title"):
+                    sched_args["title"] = label
+                self.plan_keeper.schedule_session(**{**sched_args, "user_id": user_id})
+                step_result = get_message("one_time_scheduled", user_lang)
+            except Exception as e:
+                logger.error("Error creating one-time promise for user %s: %s", user_id, e)
+                step_result = get_message("error_executing_action", user_lang, error=str(e))
+                _step_ok = False
+        elif is_confirm:
             try:
                 if hasattr(self.plan_keeper, tool_name):
                     method = getattr(self.plan_keeper, tool_name)
@@ -656,6 +683,7 @@ class CallbackHandlers:
                 "batch_remaining": remaining_after,
                 "batch_total": batch_total,
                 "batch_current_idx": next_idx,
+                "one_time_label": next_item.get("one_time_label"),
             }
             try:
                 context.user_data["pending_clarification"] = new_pending
@@ -664,10 +692,18 @@ class CallbackHandlers:
 
             yes_text = get_message("btn_yes_confirm", user_lang)
             skip_text = get_message("btn_skip_action", user_lang)
-            kb = InlineKeyboardMarkup([[
+            kb_rows = [[
                 InlineKeyboardButton(yes_text, callback_data=encode_cb("mut_confirm", d="yes")),
                 InlineKeyboardButton(skip_text, callback_data=encode_cb("mut_confirm", d="skip")),
-            ]])
+            ]]
+            if str(next_item.get("tool_name", "")) in ("schedule_session", "add_plan_session"):
+                kb_rows.append([
+                    InlineKeyboardButton(
+                        get_message("btn_track_one_time", user_lang),
+                        callback_data=encode_cb("mut_confirm", d="one_time"),
+                    ),
+                ])
+            kb = InlineKeyboardMarkup(kb_rows)
             try:
                 await query.edit_message_text(next_q, reply_markup=kb)
             except Exception:

--- a/tm_bot/handlers/message_handlers.py
+++ b/tm_bot/handlers/message_handlers.py
@@ -307,16 +307,27 @@ class MessageHandlers:
         reason = str(pending.get("reason", "")).strip().lower()
         return reason == "pre_mutation_confirmation"
 
-    def _mutation_confirmation_kb(self, user_lang: Language) -> InlineKeyboardMarkup:
-        """Inline keyboard for mutation confirmation (Yes / Skip)."""
+    def _mutation_confirmation_kb(self, user_lang: Language, pending: Optional[dict] = None) -> InlineKeyboardMarkup:
+        """Inline keyboard for mutation confirmation (Yes / Skip).
+
+        For a scheduled-session confirmation, also offer "track as a one-time promise" so the
+        user can opt out of attaching the session to the matched promise (even when one was found).
+        """
         yes_text = get_message("btn_yes_confirm", user_lang)
         skip_text = get_message("btn_skip_action", user_lang)
-        return InlineKeyboardMarkup(
-            [[
-                InlineKeyboardButton(yes_text, callback_data=encode_cb("mut_confirm", d="yes")),
-                InlineKeyboardButton(skip_text, callback_data=encode_cb("mut_confirm", d="skip")),
-            ]]
-        )
+        rows = [[
+            InlineKeyboardButton(yes_text, callback_data=encode_cb("mut_confirm", d="yes")),
+            InlineKeyboardButton(skip_text, callback_data=encode_cb("mut_confirm", d="skip")),
+        ]]
+        tool_name = str((pending or {}).get("tool_name", "")).strip()
+        if tool_name in ("schedule_session", "add_plan_session"):
+            rows.append([
+                InlineKeyboardButton(
+                    get_message("btn_track_one_time", user_lang),
+                    callback_data=encode_cb("mut_confirm", d="one_time"),
+                ),
+            ])
+        return InlineKeyboardMarkup(rows)
 
     def _sync_llm_external_turn(
         self,
@@ -820,7 +831,7 @@ class MessageHandlers:
                 response_text = llm_response.get("response_to_user", "")
                 formatted_response = self._format_response(response_text, func_call_response)
                 confirmation_kb = (
-                    self._mutation_confirmation_kb(user_lang)
+                    self._mutation_confirmation_kb(user_lang, llm_response.get("pending_clarification"))
                     if self._is_pre_mutation_confirmation(llm_response)
                     else None
                 )
@@ -1665,12 +1676,13 @@ class MessageHandlers:
                                         "batch_remaining": remaining_after,
                                         "batch_total": batch_total,
                                         "batch_current_idx": next_idx,
+                                        "one_time_label": next_item.get("one_time_label"),
                                     }
                                     try:
                                         context.user_data["pending_clarification"] = new_pending
                                     except Exception:
                                         pass
-                                    kb = self._mutation_confirmation_kb(user_lang)
+                                    kb = self._mutation_confirmation_kb(user_lang, new_pending)
                                     await self.response_service.reply_text(
                                         update, next_q,
                                         user_id=user_id,
@@ -1909,7 +1921,7 @@ class MessageHandlers:
                 
                 formatted_response = self._format_response(response_text, func_call_response)
                 confirmation_kb = (
-                    self._mutation_confirmation_kb(user_lang)
+                    self._mutation_confirmation_kb(user_lang, llm_response.get("pending_clarification"))
                     if self._is_pre_mutation_confirmation(llm_response)
                     else None
                 )

--- a/tm_bot/handlers/messages_store.py
+++ b/tm_bot/handlers/messages_store.py
@@ -171,6 +171,8 @@ class MessageTemplateStore:
             "btn_no_cancel": "No (cancel)",
             "btn_yes_confirm": "✅ Yes",
             "btn_skip_action": "⏭️ Skip",
+            "btn_track_one_time": "📝 One-time",
+            "one_time_scheduled": "✅ Added as a one-time task and scheduled it.",
             "btn_looks_right": "Looks right ✅ ({time})",
             "btn_adjust": "Adjust…",
             "btn_share_location": "Share location",

--- a/tm_bot/llms/agent.py
+++ b/tm_bot/llms/agent.py
@@ -82,6 +82,22 @@ def _parse_from_tool(val: str) -> Optional[tuple]:
     return m.group(1).strip(), m.group(2).strip()
 
 
+# Resolver / read-only lookup tools. Their outputs are what FROM_TOOL: and
+# FROM_SEARCH placeholders consume, so they must always execute *before* any
+# mutation that depends on them can be previewed. They have no side effects and
+# are therefore never gated behind user confirmation — even when the planner sets
+# safety.requires_confirmation. Gating them would (a) prevent placeholder
+# substitution, leaking raw FROM_SEARCH / FROM_TOOL text into the confirmation
+# preview, and (b) clutter that preview with internal lookup steps.
+_RESOLVER_READ_ONLY_TOOLS = frozenset({"resolve_datetime", "search_promises"})
+
+
+def _is_read_only_step(tool_name: str) -> bool:
+    """True for resolver / read-only lookup steps that must never require confirmation."""
+    name = tool_name or ""
+    return name in _RESOLVER_READ_ONLY_TOOLS or name.startswith(("get_", "list_", "search_"))
+
+
 def message_content_to_str(content: Any) -> str:
     """
     Normalize message content to a string.
@@ -790,6 +806,23 @@ def _fallback_datetime_text_from_user_text(text: str) -> Optional[str]:
     """
     source = (text or "").strip()
     return source or None
+
+
+def _one_time_label_from(tool_args: dict, user_text: str) -> str:
+    """Best-effort label for a one-time promise created from a schedule_session confirmation.
+
+    Prefers an explicit session title, then a phrase extracted from the user's message, then a
+    trimmed snippet of it. The user can rename later; the point is to capture the activity rather
+    than attach it to a wrong existing promise.
+    """
+    title = str((tool_args or {}).get("title") or "").strip()
+    if title:
+        return title[:60]
+    extracted = _extract_promise_text_from_user_text(user_text or "")
+    if extracted:
+        return str(extracted)[:60]
+    snippet = " ".join((user_text or "").split())[:60].strip()
+    return snippet or "One-time session"
 
 
 _PURPOSE_PREFIX_RE = re.compile(r"^\s*(step\s*\d+\s*[:.\-]\s*|purpose\s*[:\-]\s*)", re.IGNORECASE)
@@ -2342,6 +2375,7 @@ def create_plan_execute_graph(
                     "batch_remaining": _batch_q[1:],
                     "batch_total": _total,
                     "batch_current_idx": 0,
+                    "one_time_label": _first.get("one_time_label"),
                 }
                 return {
                     **state,
@@ -2633,7 +2667,11 @@ def create_plan_execute_graph(
             
             # Any mutation must be explicitly confirmed by the user.
             # Keep existing non-mutation safety checks as well.
-            needs_confirmation = (
+            # Read-only / resolver steps are never gated: they feed FROM_TOOL /
+            # FROM_SEARCH placeholders and must run before the mutation they feed can
+            # be previewed. Gating them (e.g. via plan-level requires_confirmation)
+            # leaks raw placeholders and internal lookup steps into the preview.
+            needs_confirmation = not _is_read_only_step(tool_name) and (
                 is_mutation_tool or
                 tool_name in ALWAYS_CONFIRM_TOOLS or
                 needs_low_confidence_confirm or
@@ -3675,6 +3713,7 @@ def create_routed_plan_execute_graph(
                     "batch_remaining": _batch_q[1:],
                     "batch_total": _total,
                     "batch_current_idx": 0,
+                    "one_time_label": _first.get("one_time_label"),
                 }
                 return {
                     **state,
@@ -3930,7 +3969,11 @@ def create_routed_plan_execute_graph(
                 intent_confidence in ("low", "medium")
             )
             
-            needs_confirmation = (
+            # Read-only / resolver steps are never gated: they feed FROM_TOOL /
+            # FROM_SEARCH placeholders and must run before the mutation they feed can
+            # be previewed. Gating them (e.g. via plan-level requires_confirmation)
+            # leaks raw placeholders and internal lookup steps into the preview.
+            needs_confirmation = not _is_read_only_step(tool_name) and (
                 is_mutation_tool or
                 tool_name in ALWAYS_CONFIRM_TOOLS or
                 needs_low_confidence_confirm or
@@ -3948,6 +3991,10 @@ def create_routed_plan_execute_graph(
                     "description": action_description,
                     "preview": _format_action_confirmation_preview(tool_name, tool_args, action_description),
                 }
+                # Carry a label so the confirmation can offer "track as a one-time promise"
+                # instead of attaching the session to the matched promise.
+                if tool_name in ("schedule_session", "add_plan_session"):
+                    _batch_item["one_time_label"] = _one_time_label_from(tool_args, user_text)
                 _current_queue = list(state.get("pending_batch_queue") or [])
                 _current_queue.append(_batch_item)
                 return {

--- a/tm_bot/llms/llm_handler.py
+++ b/tm_bot/llms/llm_handler.py
@@ -5,6 +5,7 @@ import os
 import re
 import time
 import ast
+import threading
 from collections import deque
 from contextlib import nullcontext
 from contextvars import ContextVar
@@ -1177,6 +1178,8 @@ class LLMHandler:
             self.parser = JsonOutputParser(pydantic_object=LLMResponse)
             self.max_iterations = max_iterations or int(os.getenv("LLM_MAX_ITERATIONS", "6"))
             self.chat_history: Dict[str, List[BaseMessage]] = {}
+            # Per-user message count at the last memory flush (for the turn-based trigger).
+            self._memory_flush_marks: Dict[str, int] = {}
             self._progress_callback_default = progress_callback
             self._progress_callback: Optional[Callable[[str, dict], None]] = progress_callback
 
@@ -2251,7 +2254,9 @@ class LLMHandler:
             if time.time() - last_active > timeout_seconds:
                 if safe_user_id in getattr(self, "chat_history", {}):
                     self.chat_history[safe_user_id] = []
-            
+                # New session → reset the flush mark so the turn-based trigger restarts.
+                self._memory_flush_marks.pop(safe_user_id, None)
+
             if not hasattr(self, "chat_history_timestamps"):
                 self.chat_history_timestamps = {}
             self.chat_history_timestamps[safe_user_id] = time.time()
@@ -2265,9 +2270,16 @@ class LLMHandler:
                     continue
 
             if is_flush_enabled():
+                msg_count = len(prior_history)
+                try:
+                    flush_every = int(os.getenv("MEMORY_FLUSH_EVERY_MESSAGES", "16"))
+                except Exception:
+                    flush_every = 16
                 entry = {
-                    "message_count": len(prior_history),
+                    "message_count": msg_count,
                     "estimated_tokens": max(0, prior_history_chars // 4),
+                    "flush_every_messages": flush_every,
+                    "memory_flush_message_count": self._memory_flush_marks.get(safe_user_id, 0),
                 }
                 if should_run_memory_flush(
                     entry=entry,
@@ -2275,11 +2287,22 @@ class LLMHandler:
                     reserve_tokens_floor=DEFAULT_RESERVE_TOKENS_FLOOR,
                     soft_threshold_tokens=DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
                 ):
-                    run_memory_flush(
-                        self.plan_adapter.root_dir,
-                        safe_user_id,
-                        run_flush_llm=self._run_flush_turn,
-                    )
+                    # Mark now so concurrent/next turns don't double-fire, then flush in the
+                    # background (it makes its own LLM call) so the user's reply isn't delayed.
+                    self._memory_flush_marks[safe_user_id] = msg_count
+                    history_snapshot = list(prior_history)
+                    root_dir_for_flush = self.plan_adapter.root_dir
+
+                    def _flush_llm(system_prompt: str, user_prompt: str, _hist=history_snapshot) -> str:
+                        return self._run_flush_turn(system_prompt, user_prompt, history=_hist)
+
+                    def _do_flush() -> None:
+                        try:
+                            run_memory_flush(root_dir_for_flush, safe_user_id, run_flush_llm=_flush_llm)
+                        except Exception as exc:
+                            logger.debug("background memory flush failed for %s: %s", safe_user_id, exc)
+
+                    threading.Thread(target=_do_flush, name=f"memory-flush-{safe_user_id}", daemon=True).start()
 
             memory_recall_context = self._build_memory_recall_context(safe_user_id, user_message)
             if _DEBUG_ENABLED and memory_recall_context:
@@ -3230,8 +3253,9 @@ class LLMHandler:
             "no_op",
             "maybe_ask_profile_question",
             "set_llm_handler",   # internal wiring, not a user-facing tool
-            # Superseded by LLM-based resolver added below.
+            # Superseded by LLM-based resolvers added below.
             "resolve_datetime",
+            "search_promises",
             # Async wrappers — the LLM should call the sync method instead.
             "async_get_settings",
             "async_save_settings",
@@ -3305,6 +3329,73 @@ class LLMHandler:
                     "Resolve a natural-language date/time phrase to ISO 8601. "
                     "Pass the phrase verbatim from the user message. "
                     "Returns JSON with confidence; executor handles clarification if uncertain."
+                ),
+            )
+        )
+
+        # LLM-based promise resolver — replaces the substring-only adapter search_promises.
+        # Matches by meaning (synonyms, typos, natural phrases). Keeps the adapter's output
+        # contract (single_match JSON / "Found N..." list / "No promises found...") so the
+        # FROM_SEARCH plumbing and the no-match -> one-time-promise path are unchanged.
+        def _search_promises_tool(query: str) -> str:
+            """Find a promise by description. Matches semantically (synonyms, typos, phrases)."""
+            no_match = f"No promises found matching '{query}'. Try a different search term."
+            user_id = _current_user_id.get()
+            if not user_id:
+                return no_match
+
+            # Cheap exact path: trust the substring matcher only when it finds a UNIQUE match.
+            substr_out = None
+            try:
+                substr_out = adapter.search_promises(int(user_id), query)
+            except Exception:
+                substr_out = None
+            if isinstance(substr_out, str) and substr_out.strip().startswith("{"):
+                try:
+                    if json.loads(substr_out).get("single_match"):
+                        return substr_out
+                except Exception:
+                    pass
+
+            # Semantic resolve for everything else (synonyms / typos / sentences / ambiguity).
+            try:
+                from llms.resolvers import resolve_promise_with_llm
+                promises = adapter.get_promises(int(user_id)) or []
+                r = json.loads(resolve_promise_with_llm(self.router_model, query, promises))
+                conf = r.get("confidence")
+                by_id = {str(p.get("id")): str(p.get("text") or "").replace("_", " ") for p in promises}
+
+                if conf == "high" and r.get("resolved"):
+                    pid = str(r["resolved"]).strip()
+                    ptext = by_id.get(pid, pid)
+                    return json.dumps({
+                        "single_match": True,
+                        "promise_id": pid,
+                        "promise_text": ptext,
+                        "message": f"Found best match: #{pid} {ptext}",
+                    })
+                if conf == "low" and r.get("candidates"):
+                    cands = [str(c).strip() for c in r["candidates"]]
+                    lines = [f"Found {len(cands)} promise(s) matching '{query}':\n"]
+                    for cid in cands:
+                        lines.append(f"• #{cid} **{by_id.get(cid, cid)}**")
+                    return "\n".join(lines)
+                # confidence == none -> no existing promise (caller may create a one-time promise).
+                return no_match
+            except Exception as exc:
+                logger.warning(f"search_promises semantic resolve failed: {exc}")
+                # Never worse than before: fall back to the substring result.
+                return substr_out if isinstance(substr_out, str) else no_match
+
+        tools.append(
+            StructuredTool.from_function(
+                func=_search_promises_tool,
+                name="search_promises",
+                description=(
+                    "Find a promise by description. Matches by meaning (synonyms, typos, "
+                    "natural phrases). Returns a single match when one fits, a short list when "
+                    "several do, or 'No promises found' when none relate (the activity has no "
+                    "existing promise)."
                 ),
             )
         )
@@ -3399,13 +3490,23 @@ class LLMHandler:
             )
         return tools
 
-    def _run_flush_turn(self, system_prompt: str, user_prompt: str) -> str:
-        """Run one LLM turn (no tools) for pre-compaction memory flush; returns model reply content."""
+    def _run_flush_turn(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        history: Optional[List[BaseMessage]] = None,
+    ) -> str:
+        """Run one LLM turn (no tools) for the memory flush; returns the model reply content.
+
+        The recent conversation ``history`` is included between the system and flush prompts so
+        the model has actual content to extract durable facts from. Without it the flush turn
+        would see only the instruction and reply <silent>.
+        """
         try:
-            messages = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=user_prompt),
-            ]
+            messages: List[BaseMessage] = [SystemMessage(content=system_prompt)]
+            if history:
+                messages.extend(history)
+            messages.append(HumanMessage(content=user_prompt))
             response = self.chat_model.invoke(messages)
             return getattr(response, "content", "") or ""
         except Exception as e:

--- a/tm_bot/llms/resolvers.py
+++ b/tm_bot/llms/resolvers.py
@@ -195,3 +195,118 @@ def resolve_datetime_with_llm(
                 "Could you say it more specifically? (e.g. 'tomorrow at 9am', 'Friday evening')"
             ),
         })
+
+
+# ---------------------------------------------------------------------------
+# Promise resolver
+# ---------------------------------------------------------------------------
+
+_PROMISE_SYSTEM = (
+    "You match a user's activity phrase to one of their existing promises. "
+    "Return ONLY valid JSON. No explanation."
+)
+
+_PROMISE_USER_TEMPLATE = """\
+The user has these promises (id: description):
+{promise_lines}
+
+The user referred to a promise with this phrase:
+"{query}"
+
+Match the phrase to the best promise by MEANING — handle synonyms, typos, paraphrases,
+partial names, and natural sentences (e.g. "cook dinner" -> a cooking promise,
+"phone mom" -> a call-family promise, "coding" -> a programming/robotics promise).
+
+Return ONLY JSON, using promise IDs from the list above:
+- Exactly one promise clearly fits -> {{"resolved": "<promise_id>", "confidence": "high"}}
+- 2-3 plausibly fit, cannot decide -> {{"resolved": null, "confidence": "low", "candidates": ["<id>", "<id>"], "clarification": "Which one - <A> or <B>?"}}
+- None of the promises relate to it -> {{"resolved": null, "confidence": "none"}}
+
+Format examples (illustrative only, not these promises):
+"cooking dinner tonight" -> {{"resolved": "P07", "confidence": "high"}}
+"learn spanish" -> {{"resolved": null, "confidence": "none"}}"""
+
+
+def _promise_id(p: Any) -> str:
+    return str((p.get("id") if isinstance(p, dict) else getattr(p, "id", "")) or "").strip()
+
+
+def _promise_text(p: Any) -> str:
+    return str((p.get("text") if isinstance(p, dict) else getattr(p, "text", "")) or "").strip()
+
+
+def _format_promise_lines(promises: list) -> str:
+    lines = []
+    for p in promises or []:
+        pid = _promise_id(p)
+        if not pid:
+            continue
+        lines.append(f"{pid}: {_promise_text(p).replace('_', ' ')}")
+    return "\n".join(lines)
+
+
+def resolve_promise_with_llm(model: Any, query: str, promises: list) -> str:
+    """Match *query* to one of *promises* by meaning. Returns a JSON string with ``confidence``.
+
+    JSON shape mirrors the datetime resolver so callers can branch on ``confidence``:
+      {"resolved": "P07", "confidence": "high"}
+      {"resolved": null, "confidence": "low", "candidates": [...], "clarification": "..."}
+      {"resolved": null, "confidence": "none"}
+
+    ``resolved`` is always validated against the supplied promise IDs. On any error or an
+    out-of-set id, returns ``confidence=none`` so the caller can fall back gracefully (e.g.
+    to substring search, or to creating a one-time promise).
+    """
+    valid_ids = {pid for pid in (_promise_id(p) for p in (promises or [])) if pid}
+    if not (query or "").strip() or not valid_ids:
+        return json.dumps({"resolved": None, "confidence": "none"})
+
+    try:
+        user_prompt = _PROMISE_USER_TEMPLATE.format(
+            promise_lines=_format_promise_lines(promises), query=query.strip()
+        )
+        try:
+            from langchain_core.messages import HumanMessage, SystemMessage
+
+            messages = [
+                SystemMessage(content=_PROMISE_SYSTEM),
+                HumanMessage(content=user_prompt),
+            ]
+        except ImportError:
+            messages = [
+                {"role": "system", "content": _PROMISE_SYSTEM},
+                {"role": "user", "content": user_prompt},
+            ]
+
+        raw = model.invoke(messages)
+        text = (getattr(raw, "content", None) or str(raw) or "").strip()
+        if text.startswith("```"):
+            text = text.split("```")[1]
+            if text.startswith("json"):
+                text = text[4:]
+            text = text.strip()
+
+        parsed = json.loads(text)
+        confidence = parsed.get("confidence", "none")
+
+        if confidence == "high":
+            resolved = str(parsed.get("resolved") or "").strip()
+            if resolved not in valid_ids:
+                return json.dumps({"resolved": None, "confidence": "none"})
+            return json.dumps({"resolved": resolved, "confidence": "high"})
+
+        if confidence == "low":
+            cands = [str(c).strip() for c in (parsed.get("candidates") or [])]
+            cands = [c for c in cands if c in valid_ids]
+            if not cands:
+                return json.dumps({"resolved": None, "confidence": "none"})
+            out = {"resolved": None, "confidence": "low", "candidates": cands}
+            if parsed.get("clarification"):
+                out["clarification"] = str(parsed["clarification"])
+            return json.dumps(out)
+
+        return json.dumps({"resolved": None, "confidence": "none"})
+
+    except Exception as exc:
+        logger.warning("resolve_promise_with_llm failed (%s); returning none", exc)
+        return json.dumps({"resolved": None, "confidence": "none"})

--- a/tm_bot/memory/flush.py
+++ b/tm_bot/memory/flush.py
@@ -16,16 +16,18 @@ DEFAULT_RESERVE_TOKENS_FLOOR = 2048
 DEFAULT_CONTEXT_WINDOW_TOKENS = 128000
 
 DEFAULT_MEMORY_FLUSH_PROMPT = (
-    "Pre-compaction memory flush. "
-    "Store durable memories now (use memory/YYYY-MM-DD.md; create memory/ if needed). "
-    "IMPORTANT: If the file already exists, APPEND new content only and do not overwrite existing entries. "
-    f"If nothing to store, reply with {SILENT_REPLY_TOKEN}."
+    "Review the conversation above and extract durable, reusable facts about the USER that "
+    "would help in future chats — stable preferences, goals, recurring constraints, personal "
+    "context, and working style. Skip one-off or transient details and anything trivial. "
+    "Today is YYYY-MM-DD. Reply with ONLY concise markdown bullet points, one fact per line, "
+    "no preamble. "
+    f"If there is nothing durable worth storing, reply with exactly {SILENT_REPLY_TOKEN}."
 )
 
 DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = (
-    "Pre-compaction memory flush turn. "
-    "The session is near auto-compaction; capture durable memories to disk. "
-    f"You may reply, but usually {SILENT_REPLY_TOKEN} is correct."
+    "You extract durable, long-term memories about the user from a conversation. "
+    "Capture only stable, reusable facts; ignore chit-chat and one-off details. "
+    f"Output the facts as markdown bullets, or reply with {SILENT_REPLY_TOKEN} if there are none."
 )
 
 
@@ -68,7 +70,19 @@ def should_run_memory_flush(
 
     When token count is missing, we use message_count as a proxy: if message_count >= 50 (e.g.),
     treat as "over threshold". Tune the threshold for turn-count proxy as needed.
+
+    Turn-based trigger: when ``entry['flush_every_messages']`` (N) is set, fire every N
+    messages, deduped by ``entry['memory_flush_message_count']`` (the message count at the
+    last flush). This suits a chat bot whose short, frequently-reset sessions never reach the
+    token threshold.
     """
+    interval = int((entry or {}).get("flush_every_messages") or 0)
+    if interval > 0:
+        msg_count = int((entry or {}).get("message_count") or 0)
+        last_flush_at = int((entry or {}).get("memory_flush_message_count") or 0)
+        if msg_count >= interval and (msg_count - last_flush_at) >= interval:
+            return True
+
     total_tokens = 0
     if entry:
         total_tokens = entry.get("total_tokens") or entry.get("estimated_tokens") or 0


### PR DESCRIPTION
## Summary

Three robustness fixes to the planner/agent, each driven by a measured failure. All work is backend (`tm_bot/`, `tests/`, `scripts/`) — **the parallel landing-page redesign is intentionally not included here.**

| Area | Before | After |
|---|---|---|
| Promise recall (semantic) | **46%** recall | **97%** |
| Memory capture (prod) | dormant — 4/72 users had any memory | fires every ~8 turns, extracts real facts |
| Session confirmation | leaks `FROM_SEARCH`/`FROM_TOOL` placeholders ~1/10 | clean 10/10 + a one-time opt-out |

---

## 1. Semantic promise resolver (`ad8527c`)

`search_promises` matched by case-insensitive **substring** only. On a 92-query labelled eval vs 18 real promises, recall@any was **46%** (synonyms 12%, typos 8%, natural phrases 0%). This is the *only* resolution path once a user passes the 20-promise context cap, so quality fell off a cliff at scale.

- New `resolve_promise_with_llm` (resolvers.py), mirroring the datetime resolver: returns `{resolved, confidence, candidates?}`, validates IDs.
- `search_promises` tool rewired LLM-first, with a **substring fast-path** for unique exact hits and a **substring fallback on error** (never worse than before). Output contract unchanged, so `FROM_SEARCH` plumbing is untouched.
- Re-running the eval through the resolver: **recall 46% → 97%**, clean auto-resolve 41% → 97%, miss 54% → 3%.
- Harnesses added so this stays measurable: `scripts/eval_search_promises.py`, `scripts/eval_promise_resolver_llm.py`.

## 2. Activate memory capture (`ad8527c`)

Prod had only **4/72 users** with any memory file (the most active user: none). Two causes, both fixed:
- Flush only fired near context-compaction (~122k tokens / 50 msgs) — a threshold a short Telegram chat never reaches. Added a **turn-based trigger** (`MEMORY_FLUSH_EVERY_MESSAGES`, default 16 msgs ≈ 8 turns), deduped per user, reset on session timeout.
- `_run_flush_turn` invoked the model with the flush prompt but **never the conversation**, so it always replied `<silent>`. It now receives recent history and runs in a **daemon thread** (no added reply latency). Flush prompt rewritten for text extraction.
- Verified live: no-history → `<silent>`; with-history → 6 clean extracted facts.

## 3. Confirmation-gate fix + one-time session option (`0a7b3d6`)

- **Placeholder leak:** when the planner set `requires_confirmation`, the executor gated *every* step — including read-only `search_promises`/`resolve_datetime` — so they never ran and their `FROM_SEARCH`/`FROM_TOOL` placeholders leaked into the preview (`schedule a session on FROM_SEARCH … Proceed? (1/3)`). New `_is_read_only_step` gates confirmation on **side-effecting steps only**. Verified 10/10 clean after.
- **One-time opt-out:** the resolver occasionally over-attaches loose/novel activities (yoga→Gym). The session confirmation now shows a third inline button alongside Yes/Skip — **even when a promise matched** — so the user keeps agency. Tapping it creates a non-recurring promise (`add_promise(recurring=False)` → `T`-id) and schedules the session against it. Button auto-translates (Persian/French).

---

## Testing
- New: `test_promise_resolver.py` (10), `test_one_time_label.py`, `test_one_time_confirmation.py`; turn-trigger cases in `test_memory.py`.
- Green across resolver/memory/agent/handler suites (65+ tests). Two pre-existing `test_message_handlers.py` failures (mock lacks `async_get_settings`) are unrelated — verified they fail identically on `master`.

## Notes / follow-ups
- The final one-time button behaviour needs a real Telegram tap to eyeball; agent→pending plumbing and the keyboard/callback logic are covered by tests + compile.
- TODO (not in this PR): automatic no-match → one-time path (without a tap); multi-match disambiguation (`FROM_SEARCH` auto-selects only on a single match); de-dup of re-extracted memory facts; a Gemini-backed multilingual/slang routing eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)