### PR TITLE
Promise detail: recent sessions above planned (2026-05-31)

### DIFF
--- a/webapp_frontend/src/components/sheets/PromiseDetailSheet.tsx
+++ b/webapp_frontend/src/components/sheets/PromiseDetailSheet.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { CalendarPlus, Clock, Pencil, Timer, Trash2, Check, Users } from 'lucide-react';
+import { CalendarPlus, Clock, Pencil, Timer, Trash2, Check, Users, X } from 'lucide-react';
 import type { PromiseData, PlanSession } from '../../types';
 import { formatPromiseText } from '../../utils/activityFormat';
 import { Badge } from '../ui/Badge';
@@ -122,6 +122,22 @@ export function PromiseDetailSheet({
   }, [open, promiseId]);
 
   const upcomingSessions = planSessions.filter(s => s.status === 'planned');
+
+  // A few recent, read-only sessions (done/skipped) to show above the upcoming ones,
+  // so the sheet reads as a short timeline: what happened recently, then what's planned.
+  const RECENT_SESSIONS_LIMIT = 3;
+  const recentSessions = useMemo(
+    () =>
+      planSessions
+        .filter(s => s.status === 'done' || s.status === 'skipped')
+        .sort((a, b) => {
+          const ta = a.planned_start ? new Date(a.planned_start).getTime() : 0;
+          const tb = b.planned_start ? new Date(b.planned_start).getTime() : 0;
+          return tb - ta; // most recent first
+        })
+        .slice(0, RECENT_SESSIONS_LIMIT),
+    [planSessions],
+  );
 
   // Pre-fill values for LogActionModal from the session being marked done
   const doneSession = logDoneSessionId !== null
@@ -256,6 +272,31 @@ export function PromiseDetailSheet({
           </div>
         </>
       ) : null}
+
+      {/* Recent sessions — read-only history shown above the upcoming ones */}
+      {!sessionsLoading && recentSessions.length > 0 && (
+        <>
+          <p className="ds-eyebrow" style={{ marginTop: 16 }}>Recent</p>
+          <div className="recent-sessions-list">
+            {recentSessions.map(session => (
+              <div
+                key={session.id}
+                className={`recent-session-row recent-session-row--${session.status}`}
+              >
+                <span className="recent-session-icon" aria-hidden>
+                  {session.status === 'done' ? <Check size={12} /> : <X size={12} />}
+                </span>
+                <span className="recent-session-title">
+                  {session.title || 'Session'}
+                </span>
+                <span className="recent-session-time">
+                  {formatSessionTime(session.planned_start)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
 
       {/* Planned sessions */}
       {!sessionsLoading && upcomingSessions.length > 0 && (

--- a/webapp_frontend/src/styles/sheets.css
+++ b/webapp_frontend/src/styles/sheets.css
@@ -724,6 +724,43 @@
 .plan-session-btn--edit:hover  { background: var(--accent);    color: #fff; border-color: transparent; }
 .plan-session-btn--cal:hover   { background: var(--accent);    color: #fff; border-color: transparent; }
 
+/* Recent (past) sessions inside PromiseDetailSheet — read-only, compact rows */
+.recent-sessions-list { display: grid; gap: 4px; margin-top: 8px; }
+.recent-session-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border-radius: var(--r-8);
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.recent-session-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--fg-muted);
+}
+.recent-session-row--done .recent-session-icon { color: var(--good-500); }
+.recent-session-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.recent-session-row--skipped .recent-session-title {
+  color: var(--fg-muted);
+  text-decoration: line-through;
+}
+.recent-session-time { flex-shrink: 0; font-size: 11px; color: var(--fg-muted); }
+
 /* Add-to-calendar chooser */
 .cal-choose-row { display: grid; gap: 10px; margin-top: 6px; }
 .cal-choose-btn {


### PR DESCRIPTION
## Summary

Adds a compact, read-only **Recent** section to the full promise detail sheet (`PromiseDetailSheet`), shown **above** the existing "Scheduled sessions" list. The sheet now reads as a short timeline — what happened recently, then what's planned.

Requested behaviour:
- A few recent sessions (done/skipped) above the planned ones.
- **Read-only** (no edit/delete/calendar/done buttons) and **compact** rows — single line, tight padding — so they form a small block.
- **Only in the full detail sheet**, not the minimal card (`PromiseCardV2`).

## Details
- `done` → green check; `skipped` → muted, strikethrough title.
- Most-recent-first, capped at 3.
- **No backend change.** `getPlanSessions` already returns all statuses (`PlanSessionsRepository.list_for_promise` has no status/date filter); the component just filters `done`/`skipped`, sorts, and slices.
- New CSS: `.recent-sessions-list` / `.recent-session-row` in `sheets.css`, deliberately lighter than `.plan-session-row`.

## Testing
- `npm run build` passes (tsc + vite, no type errors).
- Additive and self-contained; renders only when recent sessions exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)