### PR TITLE
Fix datetime 'today vs tomorrow' clarification (issue #86, 2026-05-31)

### DIFF
--- a/tests/unit/test_datetime_today_tomorrow.py
+++ b/tests/unit/test_datetime_today_tomorrow.py
@@ -1,0 +1,69 @@
+"""Unit tests for the 'today vs tomorrow, same time' datetime disambiguation."""
+import os
+import sys
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tm_bot"))
+from llms.resolvers import _maybe_collapse_today_tomorrow  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+TZ = ZoneInfo("Europe/Paris")  # +02:00 in summer, matches the candidates below
+NOW = datetime(2026, 5, 31, 17, 26, tzinfo=TZ)
+
+
+def _low(cands):
+    return {"resolved": None, "confidence": "low", "candidates": cands, "clarification": "Which one?"}
+
+
+def test_picks_today_when_still_upcoming():
+    out = _maybe_collapse_today_tomorrow(
+        _low(["2026-05-31T18:00:00+02:00", "2026-06-01T18:00:00+02:00"]), NOW
+    )
+    assert out["confidence"] == "high"
+    assert out["resolved"].startswith("2026-05-31T18:00")
+
+
+def test_picks_tomorrow_when_today_already_passed():
+    now = datetime(2026, 5, 31, 19, 30, tzinfo=TZ)  # 7:30pm, the 6pm slot is gone
+    out = _maybe_collapse_today_tomorrow(
+        _low(["2026-05-31T18:00:00+02:00", "2026-06-01T18:00:00+02:00"]), now
+    )
+    assert out["confidence"] == "high"
+    assert out["resolved"].startswith("2026-06-01T18:00")
+
+
+def test_tomorrow_vs_day_after_left_as_clarification():
+    # "morning" → tomorrow 9am vs day-after 9am: earlier isn't today, so still ask.
+    out = _maybe_collapse_today_tomorrow(
+        _low(["2026-06-01T09:00:00+02:00", "2026-06-02T09:00:00+02:00"]), NOW
+    )
+    assert out["confidence"] == "low"
+    assert out.get("clarification")
+
+
+def test_different_times_left_as_clarification():
+    out = _maybe_collapse_today_tomorrow(
+        _low(["2026-05-31T18:00:00+02:00", "2026-06-01T19:00:00+02:00"]), NOW
+    )
+    assert out["confidence"] == "low"
+
+
+def test_three_candidates_left_as_clarification():
+    out = _maybe_collapse_today_tomorrow(
+        _low([
+            "2026-05-31T18:00:00+02:00",
+            "2026-06-01T18:00:00+02:00",
+            "2026-06-02T18:00:00+02:00",
+        ]),
+        NOW,
+    )
+    assert out["confidence"] == "low"
+
+
+def test_high_confidence_untouched():
+    parsed = {"resolved": "2026-05-31T18:00:00+02:00", "confidence": "high"}
+    assert _maybe_collapse_today_tomorrow(parsed, NOW) == parsed

--- a/tm_bot/llms/resolvers.py
+++ b/tm_bot/llms/resolvers.py
@@ -132,6 +132,38 @@ def _build_datetime_prompt(datetime_text: str, now_local: datetime) -> tuple[str
     return _DT_SYSTEM, _DT_USER_TEMPLATE.format(**slots)
 
 
+def _maybe_collapse_today_tomorrow(parsed: dict, now_local: datetime) -> dict:
+    """Resolve the specific "same clock time, today vs tomorrow" ambiguity instead of asking.
+
+    When the resolver is only unsure between the same time today and tomorrow (e.g. "at 6" /
+    "ساعت ۶"), prefer the nearest upcoming instance — today if it hasn't passed yet, else
+    tomorrow. The datetime prompt already says to prefer the near future, but smaller models
+    often punt to a clarification here. Other low-confidence cases ("morning", "next week",
+    tomorrow-vs-day-after) are left untouched so their clarification still happens.
+    """
+    if parsed.get("confidence") != "low":
+        return parsed
+    cands = parsed.get("candidates") or []
+    if len(cands) != 2:
+        return parsed
+    try:
+        a, b = sorted(datetime.fromisoformat(str(c)) for c in cands)
+    except Exception:
+        return parsed
+    if (a.hour, a.minute) != (b.hour, b.minute) or (b - a) != timedelta(days=1):
+        return parsed
+    now_ref = now_local
+    if a.tzinfo is not None and now_ref.tzinfo is None:
+        now_ref = now_ref.replace(tzinfo=a.tzinfo)
+    elif a.tzinfo is None and now_ref.tzinfo is not None:
+        a = a.replace(tzinfo=now_ref.tzinfo)
+        b = b.replace(tzinfo=now_ref.tzinfo)
+    if a.date() != now_ref.date():
+        return parsed  # the earlier option isn't today — keep the clarification
+    target = a if a > now_ref else b
+    return {"resolved": target.isoformat(timespec="seconds"), "confidence": "high"}
+
+
 def resolve_datetime_with_llm(
     model: Any,
     datetime_text: str,
@@ -183,6 +215,8 @@ def resolve_datetime_with_llm(
         if confidence == "high":
             resolved = parsed.get("resolved", "")
             datetime.fromisoformat(str(resolved))  # raises if invalid
+        elif confidence == "low":
+            parsed = _maybe_collapse_today_tomorrow(parsed, now_local)
         return json.dumps(parsed)
 
     except Exception as exc:


### PR DESCRIPTION
## Summary

Addresses part of **#86**. When a user gives a bare clock time (common with Persian / voice input), the datetime resolver on Groq (`llama-3.3-70b`) often punts to a clarification instead of picking the obvious near-future slot:

> at 5:26pm, "از ساعت ۶ تا ۷" → `{confidence: low, candidates: [today 6pm, tomorrow 6pm], "Which 6 pm — today or tomorrow?"}`

Today 6pm is plainly the near future, and the prompt already says *"prefer the near future"* — the smaller model just doesn't honour it.

## Fix
A small **deterministic, post-LLM** step: when the only uncertainty is the *same clock time today vs tomorrow*, resolve to the nearest upcoming instance (today if it hasn't passed, else tomorrow) at high confidence. No prompt change, no model dependence.

Narrowly scoped — these keep their clarification:
- "morning" → tomorrow 9am vs day-after 9am (earlier option isn't today)
- two different clock times
- 3+ candidates

## Testing
`tests/unit/test_datetime_today_tomorrow.py` (6 cases): today-still-upcoming → today; today-passed → tomorrow; tomorrow-vs-day-after, different-times, 3-candidates, and high-confidence all left untouched.

## Not addressed here
The bigger half of #86 — the **Persian voice message routing to chatty *engagement* instead of *operator*** (no action taken) — is a router-level Groq weakness. I reproduced it (voice transcript → engagement 3/4 runs; clean text → operator 4/4) but it needs the Gemini-backed multilingual/slang routing eval + careful router work, not a blind prompt change. See the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)