### PR TITLE
Promise detail: "Recent" widget shows activity logs (2026-05-31)

### DIFF
--- a/webapp_frontend/src/components/sheets/PromiseDetailSheet.tsx
+++ b/webapp_frontend/src/components/sheets/PromiseDetailSheet.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { CalendarPlus, Clock, Pencil, Timer, Trash2, Check, Users, X } from 'lucide-react';
+import { CalendarPlus, Clock, Pencil, Timer, Trash2, Check, Users } from 'lucide-react';
 import type { PromiseData, PlanSession } from '../../types';
 import { formatPromiseText } from '../../utils/activityFormat';
 import { Badge } from '../ui/Badge';
@@ -61,6 +61,23 @@ function formatSessionTime(isoStr: string | null): string {
   return dt.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }) + ` · ${time}`;
 }
 
+type RecentLog = { datetime: string; date: string; time_spent: number; time_str: string; notes: string | null };
+
+const RECENT_LOGS_LIMIT = 3;
+
+// Format a YYYY-MM-DD log date as Today / Yesterday / "May 31".
+function formatLogDate(dateStr: string): string {
+  const [y, m, d] = (dateStr || '').split('-').map(Number);
+  if (!y || !m || !d) return dateStr || '';
+  const dt = new Date(y, m - 1, d);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const diffDays = Math.round((today.getTime() - dt.getTime()) / 86400000);
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  return dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
 export function PromiseDetailSheet({
   open,
   promiseId,
@@ -103,6 +120,9 @@ export function PromiseDetailSheet({
   // Session being edited (opens ScheduleSheet in edit mode) / added to calendar
   const [editSession, setEditSession] = useState<PlanSession | null>(null);
   const [calendarSession, setCalendarSession] = useState<PlanSession | null>(null);
+  // A few recent activity logs (what was actually done on this promise) shown above the
+  // upcoming sessions, so the sheet reads as a short timeline: recently done, then planned.
+  const [recentLogs, setRecentLogs] = useState<RecentLog[]>([]);
 
   const reloadSessions = useCallback(() => {
     apiClient.getPlanSessions(promiseId)
@@ -118,26 +138,13 @@ export function PromiseDetailSheet({
       .then(data => { if (!cancelled) setPlanSessions(data); })
       .catch(() => {})
       .finally(() => { if (!cancelled) setSessionsLoading(false); });
+    apiClient.getPromiseLogs(promiseId, RECENT_LOGS_LIMIT)
+      .then(res => { if (!cancelled) setRecentLogs(res.logs); })
+      .catch(() => {});
     return () => { cancelled = true; };
   }, [open, promiseId]);
 
   const upcomingSessions = planSessions.filter(s => s.status === 'planned');
-
-  // A few recent, read-only sessions (done/skipped) to show above the upcoming ones,
-  // so the sheet reads as a short timeline: what happened recently, then what's planned.
-  const RECENT_SESSIONS_LIMIT = 3;
-  const recentSessions = useMemo(
-    () =>
-      planSessions
-        .filter(s => s.status === 'done' || s.status === 'skipped')
-        .sort((a, b) => {
-          const ta = a.planned_start ? new Date(a.planned_start).getTime() : 0;
-          const tb = b.planned_start ? new Date(b.planned_start).getTime() : 0;
-          return tb - ta; // most recent first
-        })
-        .slice(0, RECENT_SESSIONS_LIMIT),
-    [planSessions],
-  );
 
   // Pre-fill values for LogActionModal from the session being marked done
   const doneSession = logDoneSessionId !== null
@@ -273,27 +280,28 @@ export function PromiseDetailSheet({
         </>
       ) : null}
 
-      {/* Recent sessions — read-only history shown above the upcoming ones */}
-      {!sessionsLoading && recentSessions.length > 0 && (
+      {/* Recent logs — what was actually done on this promise (read-only) */}
+      {recentLogs.length > 0 && (
         <>
           <p className="ds-eyebrow" style={{ marginTop: 16 }}>Recent</p>
-          <div className="recent-sessions-list">
-            {recentSessions.map(session => (
-              <div
-                key={session.id}
-                className={`recent-session-row recent-session-row--${session.status}`}
-              >
-                <span className="recent-session-icon" aria-hidden>
-                  {session.status === 'done' ? <Check size={12} /> : <X size={12} />}
-                </span>
-                <span className="recent-session-title">
-                  {session.title || 'Session'}
-                </span>
-                <span className="recent-session-time">
-                  {formatSessionTime(session.planned_start)}
-                </span>
-              </div>
-            ))}
+          <div className="recent-log-list">
+            {recentLogs.map((log, index) => {
+              const note = (log.notes ?? '').trim();
+              const amount = log.time_spent > 0 ? log.time_str : '';
+              return (
+                <div key={`${log.datetime}-${index}`} className="recent-log-row">
+                  <span className="recent-log-icon" aria-hidden>
+                    <Check size={12} />
+                  </span>
+                  <span className="recent-log-title">
+                    {note || (amount ? `${amount} logged` : 'Logged')}
+                  </span>
+                  <span className="recent-log-time">
+                    {note && amount ? `${amount} · ` : ''}{formatLogDate(log.date)}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </>
       )}

--- a/webapp_frontend/src/styles/sheets.css
+++ b/webapp_frontend/src/styles/sheets.css
@@ -724,9 +724,9 @@
 .plan-session-btn--edit:hover  { background: var(--accent);    color: #fff; border-color: transparent; }
 .plan-session-btn--cal:hover   { background: var(--accent);    color: #fff; border-color: transparent; }
 
-/* Recent (past) sessions inside PromiseDetailSheet — read-only, compact rows */
-.recent-sessions-list { display: grid; gap: 4px; margin-top: 8px; }
-.recent-session-row {
+/* Recent activity logs inside PromiseDetailSheet — read-only, compact rows */
+.recent-log-list { display: grid; gap: 4px; margin-top: 8px; }
+.recent-log-row {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -735,17 +735,16 @@
   background: var(--surface);
   border: 1px solid var(--border);
 }
-.recent-session-icon {
+.recent-log-icon {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 16px;
   height: 16px;
-  color: var(--fg-muted);
+  color: var(--good-500);
 }
-.recent-session-row--done .recent-session-icon { color: var(--good-500); }
-.recent-session-title {
+.recent-log-title {
   flex: 1;
   min-width: 0;
   font-size: 12px;
@@ -755,11 +754,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.recent-session-row--skipped .recent-session-title {
-  color: var(--fg-muted);
-  text-decoration: line-through;
-}
-.recent-session-time { flex-shrink: 0; font-size: 11px; color: var(--fg-muted); }
+.recent-log-time { flex-shrink: 0; font-size: 11px; color: var(--fg-muted); white-space: nowrap; }
 
 /* Add-to-calendar chooser */
 .cal-choose-row { display: grid; gap: 10px; margin-top: 6px; }


### PR DESCRIPTION
## Summary

Follow-up to #87. You're right — a "done" plan session is about the *schedule*; what matters is **what was actually done** on the promise, including ad-hoc logs that were never a scheduled session. So the **Recent** widget now reads from the **activity log** instead of completed sessions.

## Change
- Data source: `apiClient.getPromiseLogs(promiseId, 3)` (the same endpoint the full Logs modal uses) instead of `planSessions.filter(done/skipped)`.
- Each compact row shows: a green check, the **note** ("what was done") or `"{time} logged"`, and the amount + a **relative date** (Today / Yesterday / "May 31").
- Still read-only, compact (single line), and only in the full detail sheet — not the minimal `PromiseCardV2`.
- CSS renamed `.recent-session-*` → `.recent-log-*`.

## Testing
`npm run build` passes (tsc + vite). Additive/self-contained; renders only when logs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)