### PR TITLE
Harden the adapter→tool contract (single-source exposure + snapshot test)

### DIFF
--- a/docs/ADAPTER_API_CONTRACT.md
+++ b/docs/ADAPTER_API_CONTRACT.md
@@ -1,0 +1,114 @@
+# The Adapter API contract — how to evolve `PlannerAPIAdapter` safely
+
+`tm_bot/services/planner_api_adapter.py` (`PlannerAPIAdapter`, ~67 public methods) is a
+**facade** over the repository + service layers. It is not just "internal helper code" —
+its public surface is consumed by **four** independent channels, two of which build their
+behaviour by *reflecting over it at runtime*. That makes the adapter a **published API**:
+method names, parameter names, docstrings, and return shapes are all load-bearing.
+
+This doc records what is actually contract, the hazards that follow from it, and the
+principles/mechanism for changing it without silently breaking a consumer.
+
+## The four consumers
+
+| Consumer | How it binds | Source |
+|---|---|---|
+| **Bot handlers** | Direct method calls | `tm_bot/handlers/*`, `planner_bot.py` |
+| **Webapp REST routers** (React Mini App — the "other channel") | Direct method calls | `tm_bot/webapp/routers/{promises,content,youtube_watch,admin}.py` |
+| **LLM agent** ("agent tool-model") | **Reflection**: `dir(adapter)` → denylist → docstring + signature → tool schema | `llms/llm_handler.py:3242` `_build_tools` |
+| **MCP server** (Claude / ChatGPT connectors) | **Reflection**: `dir(adapter)` → denylist → docstring + signature → tool schema, + ChatGPT `search`/`fetch` | `tm_bot/mcp_server/tools.py:73` `register_adapter_tools` |
+
+Both reflected surfaces share the same wrapper, `llms/tool_wrappers.py:47` `_wrap_tool`,
+which strips `self`/`user_id`, derives required args from no-default params, and copies the
+docstring + `__signature__` onto the model-facing tool.
+
+## What is actually "contract" (for the reflected surfaces)
+
+For the LLM and MCP surfaces, changing any of these changes the live tool surface that
+Claude/ChatGPT see — with no compiler error:
+
+1. **Method name** → tool name. Rename = a tool disappears and a new one appears.
+2. **Public parameter names / types / defaults** (after stripping `self`/`user_id`) → tool
+   input schema. **No default ⇒ required arg** (`_required_params`). Renaming `promise_id`→`pid`
+   or dropping a default is a breaking schema change.
+3. **Docstring first line** → tool description (truncated to 120 chars for the LLM,
+   `llm_handler.py:3287`; 200 for MCP, `tools.py:84`). A docstring is no longer "just a comment" —
+   it is model-facing copy.
+4. **Return type** → serialized result. MCP coerces via `mcp_server/serialization.py`
+   (`normalize_result`): dataclasses→dict, dates→ISO, prose strings passed through. The LLM
+   consumes prose directly.
+5. **Mere existence of a public method** → auto-exposed as a tool. Exposure is a **denylist**
+   (`EXCLUDED_TOOLS`), so anything new is **exposed by default**.
+
+## Hazards observed in the current code
+
+- **H1 — Exposure by default (security-relevant).** A new public adapter method is *instantly*
+  a remote-callable MCP tool for any authenticated user, unless someone remembers to add it to
+  `mcp_server/tools.py:39` `EXCLUDED_TOOLS`. Forgetting = silent remote exposure (imagine an
+  `export_all_data` or an admin helper landing on the adapter).
+- **H2 — Two denylists, already drifted.** `llm_handler.py:3245` and `tools.py:39` are
+  *separate* hand-maintained sets and are **not** in sync despite the comment claiming they
+  mirror each other:
+  - Exposed to **MCP but hidden from the LLM**: `search_promises`, `resolve_datetime`.
+  - Hidden from **MCP but exposed to the LLM**: `schedule_sessions`, `create_reminders`,
+    `log_completed_activities`, `clear_profile_pending_question`.
+  Some of this is intentional (MCP keeps singular write-verbs, drops batch variants) — but
+  nothing enforces or documents which divergences are deliberate.
+- **H3 — Docstring-as-API.** Editing a method's first docstring line silently rewrites the tool
+  description on both model surfaces. A "tidy-up" comment edit is a behaviour change.
+- **H4 — Return-shape duality.** Many methods return chat-formatted *prose strings* (built for
+  the Telegram UI). Programmatic surfaces (MCP, REST) want structured JSON. Migrating a method
+  string→dict helps MCP/REST but changes what the LLM prompt sees mid-conversation.
+- **H5 — No guard.** Nothing in CI fails when the reflected tool surface changes, so the blast
+  radius of an adapter edit is invisible in code review.
+
+## Principles for future development
+
+**P1. Treat the adapter's public surface as a published API.** If a method is `public` on
+`PlannerAPIAdapter`, assume ≥4 channels depend on it. Internal-only logic belongs on a
+repository/service, or is named with a leading underscore.
+
+**P2. Single source of truth for exposure — flip denylist → explicit policy.** Replace the two
+`EXCLUDED_TOOLS` sets with one shared classification that both `_build_tools` and
+`register_adapter_tools` import. New methods default to **not exposed** until classified.
+
+**P3. Co-locate the policy with the code.** Prefer an explicit marker on the method over a
+distant list — e.g. a decorator `@expose(surfaces={"llm", "mcp"})` / `@internal`, read by both
+reflectors. Exposure intent then lives next to the method and travels with it in diffs.
+
+**P4. Docstrings and signatures are contract.** Write the first docstring line *for a model*.
+Keep parameter names stable and descriptive. Treat param rename / removal / new-required and
+return-shape changes as **breaking** and call them out in the PR.
+
+**P5. Add a contract-snapshot test (the mechanism).** Generate a golden snapshot of the reflected
+surface — `{tool_name: {params, required, description, surfaces}}` — and diff it in CI. Any change
+to the model-facing surface must be acknowledged by updating the snapshot in the *same* PR. This
+is what makes "how does this change impact MCP / the LLM / the Mini App" show up automatically in
+review, instead of being discovered in production.
+
+**P6. Separate read vs write and tag sensitivity.** Mark mutating / destructive / admin / PII
+methods. Remote MCP exposure of a *write* should be a deliberate opt-in, not a denylist oversight.
+(The ChatGPT `search`/`fetch` tools are read-only by design — extend that discipline.)
+
+**P7. Return-shape policy.** Prefer structured returns for new methods. Where a method must
+return chat prose, either add a structured sibling or let `serialization.normalize_result` own
+the conversion — don't change an existing method's return shape without checking the LLM
+prompt-side expectations.
+
+**P8. Retire, don't delete.** Canonical one-tool-per-intent is good (e.g. `add_action` →
+`log_completed_activity`). Retire superseded names by *excluding them from reflection*, not by
+deleting the method — handlers and REST routers may still call them directly. Deleting a method
+is breaking for the direct-call channels too.
+
+**P9. "Touching the adapter" PR checklist.**
+- [ ] Added a public method? → classify its exposure (P2/P3); default is internal.
+- [ ] Renamed a param / changed a default / changed return shape? → flagged as breaking (P4/P7).
+- [ ] Edited a docstring first line? → that's model-facing copy (P3/P4).
+- [ ] Is it a write / admin / PII method going to MCP? → deliberate opt-in (P6).
+- [ ] Updated the contract snapshot (P5)?
+
+## Suggested next step
+
+Implement **P5** first — it is the smallest change that makes every later adapter edit
+self-policing — then **P2/P3** to collapse the drifting denylists into one policy. Both are
+additive and don't change runtime behaviour.

--- a/tm_bot/llms/llm_handler.py
+++ b/tm_bot/llms/llm_handler.py
@@ -3241,35 +3241,11 @@ class LLMHandler:
 
     def _build_tools(self, adapter: PlannerAPIAdapter):
         """Convert adapter methods into LangChain StructuredTool objects."""
-        # Exclude tools that add too much context or are rarely needed
-        EXCLUDED_TOOLS = {
-            "query_database",  # SQL tool - complex, rarely needed, adds schema bloat
-            "get_db_schema",   # Database schema - on-demand only
-            # Back-compat aliases superseded by user-verb names below; hidden from
-            # the LLM so the planner only sees one canonical tool per intent.
-            "add_action",          # → log_completed_activity
-            "add_plan_session",    # → schedule_session
-            # Internal helpers that pollute the planner's tool vocabulary.
-            "no_op",
-            "maybe_ask_profile_question",
-            "set_llm_handler",   # internal wiring, not a user-facing tool
-            # Superseded by LLM-based resolvers added below.
-            "resolve_datetime",
-            "search_promises",
-            # Async wrappers — the LLM should call the sync method instead.
-            "async_get_settings",
-            "async_save_settings",
-            "async_get_promises",
-            "async_get_promise_report",
-            "async_get_weekly_summary",
-            # Redundant DataFrame variant; get_actions covers the LLM use case.
-            "get_actions_df",
-            # Background content-pipeline helpers; called from non-LLM code paths.
-            "process_shared_link",
-            "estimate_time_for_content",
-            "summarize_content",
-        }
-        
+        # Exposure is governed centrally — see llms/tool_exposure.py and
+        # docs/ADAPTER_API_CONTRACT.md. New public adapter methods are exposed
+        # by default unless listed there.
+        from llms.tool_exposure import LLM_EXCLUDED_TOOLS as EXCLUDED_TOOLS
+
         tools = []
         for attr_name in dir(adapter):
             if attr_name.startswith("_"):

--- a/tm_bot/llms/tool_exposure.py
+++ b/tm_bot/llms/tool_exposure.py
@@ -1,0 +1,88 @@
+"""Single source of truth for which ``PlannerAPIAdapter`` methods are exposed as tools.
+
+Two channels reflect the adapter into a model-facing tool surface:
+
+* the in-app LLM agent — ``llms.llm_handler.PlannerLLMHandler._build_tools``
+* the MCP server — ``tm_bot.mcp_server.tools.register_adapter_tools``
+
+Both iterate ``dir(adapter)`` and expose every public method *except* the names
+listed here. Exposure is therefore a **denylist**: a newly added public adapter
+method is exposed by default. When you add a public method, decide whether it
+should reach the LLM and/or remote MCP clients and, if not, add it to the
+relevant set below.
+
+The two sets are intentionally allowed to differ (e.g. MCP keeps the singular
+write-verbs and drops batch variants), but keeping them in one file makes the
+differences reviewable. ``docs/ADAPTER_API_CONTRACT.md`` explains the policy, and
+``tm_bot/tests/test_adapter_tool_contract.py`` snapshots the resulting surface so
+any drift shows up in review.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Set
+
+# Excluded from the LLM agent's tool surface.
+LLM_EXCLUDED_TOOLS: Set[str] = {
+    "query_database",   # SQL tool - complex, rarely needed, adds schema bloat
+    "get_db_schema",    # Database schema - on-demand only
+    # Back-compat aliases superseded by user-verb names; hidden so the planner
+    # only sees one canonical tool per intent.
+    "add_action",          # → log_completed_activity
+    "add_plan_session",    # → schedule_session
+    # Internal helpers that pollute the planner's tool vocabulary.
+    "no_op",
+    "maybe_ask_profile_question",
+    "set_llm_handler",   # internal wiring, not a user-facing tool
+    # Superseded by LLM-based resolvers added in _build_tools.
+    "resolve_datetime",
+    "search_promises",
+    # Async wrappers — the LLM should call the sync method instead.
+    "async_get_settings",
+    "async_save_settings",
+    "async_get_promises",
+    "async_get_promise_report",
+    "async_get_weekly_summary",
+    # Redundant DataFrame variant; get_actions covers the LLM use case.
+    "get_actions_df",
+    # Background content-pipeline helpers; called from non-LLM code paths.
+    "process_shared_link",
+    "estimate_time_for_content",
+    "summarize_content",
+}
+
+# Excluded from the remote MCP tool surface. Shares the LLM exclusions for the
+# internal/unsafe/redundant methods (raw SQL, internal helpers, the async_*
+# duplicates of sync methods, resolve_datetime, and search_promises — the
+# ChatGPT `search`/`fetch` tools cover remote search), then diverges
+# deliberately by *also* hiding the batch/plural write variants (keeping the
+# singular forms schedule_session / log_completed_activity / create_reminder)
+# and clear_profile_pending_question (bot-flow only).
+MCP_EXCLUDED_TOOLS: Set[str] = LLM_EXCLUDED_TOOLS | {
+    "clear_profile_pending_question",
+    "schedule_sessions",
+    "log_completed_activities",
+    "create_reminders",
+}
+
+
+def public_adapter_methods(adapter_or_cls) -> List[str]:
+    """Public (non-underscore) callable attribute names on an adapter or its class.
+
+    Accepts either an instance or the class so callers (and the contract test)
+    can enumerate the surface without instantiating the adapter.
+    """
+    names: List[str] = []
+    for attr_name in dir(adapter_or_cls):
+        if attr_name.startswith("_"):
+            continue
+        if not callable(getattr(adapter_or_cls, attr_name, None)):
+            continue
+        names.append(attr_name)
+    return names
+
+
+def exposed_tools(adapter_or_cls, excluded: Iterable[str]) -> List[str]:
+    """Tool names a reflecting surface would expose: public methods minus ``excluded``."""
+    excluded_set = set(excluded)
+    return sorted(n for n in public_adapter_methods(adapter_or_cls) if n not in excluded_set)

--- a/tm_bot/mcp_server/tools.py
+++ b/tm_bot/mcp_server/tools.py
@@ -24,6 +24,7 @@ from typing import List
 from pydantic import BaseModel, Field
 
 from llms.tool_wrappers import _wrap_tool
+from llms.tool_exposure import MCP_EXCLUDED_TOOLS as EXCLUDED_TOOLS
 from utils.logger import get_logger
 
 from .config import config
@@ -32,27 +33,9 @@ from .serialization import normalize_result
 
 logger = get_logger(__name__)
 
-
-# Methods not exposed as tools. Mirrors the LLM exclusion list plus MCP-specific
-# omissions: raw SQL (unsafe for remote clients), batch plural variants (kept the
-# singular forms), and content-pipeline helpers driven by non-MCP code.
-EXCLUDED_TOOLS = {
-    "query_database",
-    "get_db_schema",
-    "add_action",
-    "add_plan_session",
-    "no_op",
-    "maybe_ask_profile_question",
-    "clear_profile_pending_question",
-    "set_llm_handler",
-    "schedule_sessions",
-    "log_completed_activities",
-    "create_reminders",
-    "process_shared_link",
-    "estimate_time_for_content",
-    "summarize_content",
-    "get_actions_df",
-}
+# Which adapter methods are exposed here is governed centrally — see
+# llms/tool_exposure.py and docs/ADAPTER_API_CONTRACT.md. New public adapter
+# methods are exposed by default unless listed there.
 
 
 def _bound_tool(fn):

--- a/tm_bot/services/planner_api_adapter.py
+++ b/tm_bot/services/planner_api_adapter.py
@@ -553,10 +553,19 @@ class PlannerAPIAdapter:
         """Get a specific promise by ID."""
         return self.promises_repo.get_promise(user_id, promise_id)
 
-    def get_promises(self, user_id) -> List[Dict]:
-        """List the user's promises (id, text, weekly hours, dates). Use to look up promise_ids."""
+    def get_promises(self, user_id, status: str = "all") -> List[Dict]:
+        """List the user's promises with id, text, tracking ('time'|'count') and status ('active'|'expired'). Use to look up promise_ids.
+
+        Args:
+            status: filter the list — "active" (not past its end date), "expired"
+                (past its end date but still listed), or "all" (default).
+        """
         promises = self.promises_repo.list_promises(user_id)
-        return [self._promise_to_dict(p) for p in promises]
+        dicts = [self._promise_to_dict(p) for p in promises]
+        wanted = (status or "all").strip().lower()
+        if wanted in ("active", "expired"):
+            dicts = [d for d in dicts if d["status"] == wanted]
+        return dicts
     
     def count_promises(self, user_id) -> int:
         """Get total number of promises for a user."""
@@ -1291,10 +1300,20 @@ class PlannerAPIAdapter:
         return f"{promise_type}{(last_id+1):02d}"
 
     def _promise_to_dict(self, promise: Promise) -> Dict:
-        """Convert Promise model to legacy dict format."""
+        """Convert Promise model to a dict for adapter consumers (LLM/MCP/handlers).
+
+        ``tracking`` ('time'|'count') and ``status`` ('active'|'expired') are the
+        model-facing way to describe a promise. ``hours_per_week`` is retained for
+        back-compat (bot handlers read it; it also encodes tracking via the
+        <=0 convention) but is a legacy weekly *target* the product no longer
+        emphasizes — prefer ``tracking`` + recent activity when describing a promise.
+        """
+        is_expired = bool(promise.end_date and promise.end_date < date.today())
         return {
             'id': promise.id,
             'text': promise.text,
+            'tracking': 'count' if promise.is_check_based() else 'time',
+            'status': 'expired' if is_expired else 'active',
             'hours_per_week': promise.hours_per_week,
             'recurring': promise.recurring,
             'end_date': promise.end_date.isoformat() if promise.end_date else '',

--- a/tm_bot/tests/adapter_tool_contract.snapshot.json
+++ b/tm_bot/tests/adapter_tool_contract.snapshot.json
@@ -1,0 +1,730 @@
+{
+  "adapter_methods": {
+    "add_checkin": {
+      "doc": "Record a yes/no check-in for a count-based promise. Use 'I did it today'-style messages.",
+      "params": [
+        "promise_id",
+        "action_datetime"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "add_promise": {
+      "doc": "Create an ongoing tracked goal the user wants to measure over time.",
+      "params": [
+        "promise_text",
+        "num_hours_promised_per_week",
+        "recurring",
+        "start_date",
+        "end_date"
+      ],
+      "required": [
+        "promise_text",
+        "num_hours_promised_per_week"
+      ]
+    },
+    "async_get_promise_report": {
+      "doc": "Non-blocking wrapper for get_promise_report.",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "async_get_promises": {
+      "doc": "Non-blocking wrapper for get_promises.",
+      "params": [],
+      "required": []
+    },
+    "async_get_settings": {
+      "doc": "Non-blocking wrapper for settings_service.get_settings.",
+      "params": [],
+      "required": []
+    },
+    "async_get_weekly_summary": {
+      "doc": "Non-blocking wrapper for reports_service.get_weekly_summary.",
+      "params": [
+        "ref_time"
+      ],
+      "required": []
+    },
+    "async_save_settings": {
+      "doc": "Non-blocking wrapper for settings_service.save_settings.",
+      "params": [
+        "settings"
+      ],
+      "required": [
+        "settings"
+      ]
+    },
+    "cancel_reminder": {
+      "doc": "Cancel (disable) a recurring reminder by its reminder_id.",
+      "params": [
+        "reminder_id"
+      ],
+      "required": [
+        "reminder_id"
+      ]
+    },
+    "clear_profile_pending_question": {
+      "doc": "Clear the pending profile question (call after user answers it).",
+      "params": [],
+      "required": []
+    },
+    "count_actions_on_date": {
+      "doc": "Count logged actions on a specific date (YYYY-MM-DD) based on actions.csv.",
+      "params": [
+        "date_iso"
+      ],
+      "required": [
+        "date_iso"
+      ]
+    },
+    "count_actions_today": {
+      "doc": "Count actions for 'today' in the user's timezone from settings.",
+      "params": [],
+      "required": []
+    },
+    "count_promises": {
+      "doc": "Get total number of promises for a user.",
+      "params": [],
+      "required": []
+    },
+    "create_recurring_reminder": {
+      "doc": "Create a weekly recurring reminder ping for a promise.",
+      "params": [
+        "promise_id",
+        "weekday",
+        "time_local"
+      ],
+      "required": [
+        "promise_id",
+        "weekday",
+        "time_local"
+      ]
+    },
+    "create_reminder": {
+      "doc": "Create a one-off reminder for a future date.",
+      "params": [
+        "text",
+        "remind_at"
+      ],
+      "required": [
+        "text",
+        "remind_at"
+      ]
+    },
+    "create_reminders": {
+      "doc": "Create MULTIPLE one-off reminders in ONE call. Use when the user lists 2+ things to remember.",
+      "params": [
+        "items"
+      ],
+      "required": [
+        "items"
+      ]
+    },
+    "delete_plan_session": {
+      "doc": "Cancel and delete a scheduled session for a promise.",
+      "params": [
+        "session_id"
+      ],
+      "required": [
+        "session_id"
+      ]
+    },
+    "delete_promise": {
+      "doc": "Delete a promise by id. Always require user confirmation first.",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "estimate_time_for_content": {
+      "doc": "Estimate time needed for content.",
+      "params": [
+        "content_type",
+        "metadata"
+      ],
+      "required": [
+        "content_type",
+        "metadata"
+      ]
+    },
+    "follow_user": {
+      "doc": "Follow another user by their username.",
+      "params": [
+        "target_username"
+      ],
+      "required": [
+        "target_username"
+      ]
+    },
+    "get_actions": {
+      "doc": "Get all actions for a user (legacy format).",
+      "params": [],
+      "required": []
+    },
+    "get_actions_df": {
+      "doc": "Get actions as DataFrame (for compatibility).",
+      "params": [],
+      "required": []
+    },
+    "get_actions_on_date": {
+      "doc": "Return action rows on a specific date (YYYY-MM-DD).",
+      "params": [
+        "date_iso"
+      ],
+      "required": [
+        "date_iso"
+      ]
+    },
+    "get_all_hours_total": {
+      "doc": "Get total hours logged across all promises, optionally within a date range.",
+      "params": [
+        "since_date",
+        "until_date"
+      ],
+      "required": []
+    },
+    "get_community_stats": {
+      "doc": "Get your community statistics (follower and following counts).",
+      "params": [],
+      "required": []
+    },
+    "get_db_schema": {
+      "doc": "Get database schema and example queries for query_database tool.",
+      "params": [],
+      "required": []
+    },
+    "get_last_action_on_promise": {
+      "doc": "Get last action for a promise (legacy format).",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "get_my_followers": {
+      "doc": "Get list of users who follow you.",
+      "params": [],
+      "required": []
+    },
+    "get_my_following": {
+      "doc": "Get list of users you follow.",
+      "params": [],
+      "required": []
+    },
+    "get_overload_status": {
+      "doc": "Check if user is overloaded with too many active promises and suggest reducing scope.",
+      "params": [],
+      "required": []
+    },
+    "get_plan_sessions": {
+      "doc": "List all scheduled sessions for a promise (planned, done, and skipped).",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "get_profile_status": {
+      "doc": "Get user profile status: completion, known facts, missing fields, pending question.",
+      "params": [],
+      "required": []
+    },
+    "get_promise": {
+      "doc": "Get a specific promise by ID.",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "get_promise_hours_total": {
+      "doc": "Get total hours logged for a promise, optionally within a date range.",
+      "params": [
+        "promise_id",
+        "since_date",
+        "until_date"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "get_promise_report": {
+      "doc": "Get promise report.",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "get_promise_streak": {
+      "doc": "Get promise streak.",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "get_promise_weekly_progress": {
+      "doc": "Get weekly progress for a promise.",
+      "params": [
+        "promise_id"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "get_promises": {
+      "doc": "List the user's promises with id, text, tracking ('time'|'count') and status ('active'|'expired'). Use to look up promise_ids.",
+      "params": [
+        "status"
+      ],
+      "required": []
+    },
+    "get_setting": {
+      "doc": "Get a single user setting value by key (timezone, nightly_hh, nightly_mm, language, voice_mode).",
+      "params": [
+        "setting_key"
+      ],
+      "required": [
+        "setting_key"
+      ]
+    },
+    "get_settings": {
+      "doc": "Get user settings as a dict (timezone, nightly time, language, voice mode).",
+      "params": [],
+      "required": []
+    },
+    "get_template": {
+      "doc": "Get details for a specific template.",
+      "params": [
+        "template_id"
+      ],
+      "required": [
+        "template_id"
+      ]
+    },
+    "get_tool_help": {
+      "doc": "Get detailed documentation for a specific tool.",
+      "params": [
+        "tool_name"
+      ],
+      "required": [
+        "tool_name"
+      ]
+    },
+    "get_upcoming_sessions": {
+      "doc": "Get all planned sessions across all promises for the next N days (default 7).",
+      "params": [
+        "days_ahead"
+      ],
+      "required": []
+    },
+    "get_weekly_report": {
+      "doc": "Get the user's weekly progress report (hours logged vs promised per goal).",
+      "params": [
+        "reference_time"
+      ],
+      "required": []
+    },
+    "get_weekly_visualization": {
+      "doc": "Generate weekly visualization image for a user.",
+      "params": [
+        "reference_time"
+      ],
+      "required": []
+    },
+    "get_work_hour_suggestion": {
+      "doc": "Get work hour suggestion based on user patterns.",
+      "params": [
+        "day_of_week"
+      ],
+      "required": []
+    },
+    "list_actions_filtered": {
+      "doc": "Get list of actions with optional filtering by promise and date range.",
+      "params": [
+        "promise_id",
+        "since_date",
+        "until_date"
+      ],
+      "required": []
+    },
+    "list_templates": {
+      "doc": "List available promise templates, optionally filtered by category.",
+      "params": [
+        "category"
+      ],
+      "required": []
+    },
+    "log_completed_activities": {
+      "doc": "Log MULTIPLE completed activities in ONE call. Use when the user reports 2+ done things.",
+      "params": [
+        "items"
+      ],
+      "required": [
+        "items"
+      ]
+    },
+    "log_completed_activity": {
+      "doc": "Log time spent on a promise for an activity the user has ALREADY completed.",
+      "params": [
+        "promise_id",
+        "time_spent",
+        "action_datetime",
+        "notes"
+      ],
+      "required": [
+        "promise_id",
+        "time_spent"
+      ]
+    },
+    "log_distraction": {
+      "doc": "Log a distraction event (for budget templates).",
+      "params": [
+        "category",
+        "minutes",
+        "at"
+      ],
+      "required": [
+        "category",
+        "minutes"
+      ]
+    },
+    "mark_session_done": {
+      "doc": "Mark a scheduled session as completed.",
+      "params": [
+        "session_id"
+      ],
+      "required": [
+        "session_id"
+      ]
+    },
+    "mark_session_skipped": {
+      "doc": "Mark a scheduled session as skipped (no time logged).",
+      "params": [
+        "session_id"
+      ],
+      "required": [
+        "session_id"
+      ]
+    },
+    "maybe_ask_profile_question": {
+      "doc": "Check if we should ask a profile question and enqueue it if eligible.",
+      "params": [],
+      "required": []
+    },
+    "no_op": {
+      "doc": "No-op method for testing purposes.",
+      "params": [],
+      "required": []
+    },
+    "open_mini_app": {
+      "doc": "Open the mini app for the user.",
+      "params": [
+        "path",
+        "context"
+      ],
+      "required": []
+    },
+    "process_shared_link": {
+      "doc": "Process a shared link and return formatted summary with time estimate.",
+      "params": [
+        "url"
+      ],
+      "required": [
+        "url"
+      ]
+    },
+    "query_database": {
+      "doc": "Execute a read-only SQL query against your data for complex analytics.",
+      "params": [
+        "sql_query"
+      ],
+      "required": [
+        "sql_query"
+      ]
+    },
+    "resolve_datetime": {
+      "doc": "Resolve a date/time phrase ('tomorrow 3pm') to ISO; translate non-English idioms first.",
+      "params": [
+        "datetime_text"
+      ],
+      "required": [
+        "datetime_text"
+      ]
+    },
+    "schedule_session": {
+      "doc": "Schedule a FUTURE work session (time block) tied to an existing promise.",
+      "params": [
+        "promise_id",
+        "title",
+        "planned_start",
+        "planned_duration_min",
+        "notes"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "schedule_sessions": {
+      "doc": "Schedule MULTIPLE future sessions in ONE call. Use when the user lists 2+ activities to plan.",
+      "params": [
+        "items"
+      ],
+      "required": [
+        "items"
+      ]
+    },
+    "search_promises": {
+      "doc": "Find a user's promise_id by free-text query. Use when promise_id is unknown.",
+      "params": [
+        "query"
+      ],
+      "required": [
+        "query"
+      ]
+    },
+    "set_language": {
+      "doc": "Set the user's preferred reply language.",
+      "params": [
+        "language"
+      ],
+      "required": [
+        "language"
+      ]
+    },
+    "set_llm_handler": {
+      "doc": "Set LLM handler for content management and time estimation services.",
+      "params": [
+        "llm_handler"
+      ],
+      "required": [
+        "llm_handler"
+      ]
+    },
+    "set_timezone": {
+      "doc": "Set the user's timezone (affects all date/time interpretation).",
+      "params": [
+        "timezone"
+      ],
+      "required": [
+        "timezone"
+      ]
+    },
+    "subscribe_template": {
+      "doc": "Subscribe to a template (creates a promise and instance).",
+      "params": [
+        "template_id",
+        "start_date",
+        "target_date"
+      ],
+      "required": [
+        "template_id"
+      ]
+    },
+    "summarize_content": {
+      "doc": "Summarize content using LLM.",
+      "params": [
+        "url",
+        "content_metadata"
+      ],
+      "required": [
+        "url",
+        "content_metadata"
+      ]
+    },
+    "unfollow_user": {
+      "doc": "Unfollow a user by their username.",
+      "params": [
+        "target_username"
+      ],
+      "required": [
+        "target_username"
+      ]
+    },
+    "update_plan_session_status": {
+      "doc": "Mark a planned session as done, skipped, or back to planned.",
+      "params": [
+        "session_id",
+        "status"
+      ],
+      "required": [
+        "session_id",
+        "status"
+      ]
+    },
+    "update_promise": {
+      "doc": "Update an existing promise's text, hours/week, recurrence, or dates (only sets fields you pass).",
+      "params": [
+        "promise_id",
+        "promise_text",
+        "hours_per_week",
+        "recurring",
+        "start_date",
+        "end_date"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "update_promise_start_date": {
+      "doc": "Update promise start date.",
+      "params": [
+        "promise_id",
+        "new_start_date"
+      ],
+      "required": [
+        "promise_id",
+        "new_start_date"
+      ]
+    },
+    "update_setting": {
+      "doc": "Update a low-level user setting by key/value. Prefer set_language or set_timezone.",
+      "params": [
+        "setting_key",
+        "setting_value"
+      ],
+      "required": [
+        "setting_key",
+        "setting_value"
+      ]
+    },
+    "upsert_profile_fact": {
+      "doc": "Upsert a profile fact (e.g., status, schedule_type, primary_goal_1y, top_focus_area, main_constraint).",
+      "params": [
+        "field_key",
+        "field_value",
+        "source",
+        "confidence"
+      ],
+      "required": [
+        "field_key",
+        "field_value"
+      ]
+    }
+  },
+  "llm_exposed": [
+    "add_checkin",
+    "add_promise",
+    "cancel_reminder",
+    "clear_profile_pending_question",
+    "count_actions_on_date",
+    "count_actions_today",
+    "count_promises",
+    "create_recurring_reminder",
+    "create_reminder",
+    "create_reminders",
+    "delete_plan_session",
+    "delete_promise",
+    "follow_user",
+    "get_actions",
+    "get_actions_on_date",
+    "get_all_hours_total",
+    "get_community_stats",
+    "get_last_action_on_promise",
+    "get_my_followers",
+    "get_my_following",
+    "get_overload_status",
+    "get_plan_sessions",
+    "get_profile_status",
+    "get_promise",
+    "get_promise_hours_total",
+    "get_promise_report",
+    "get_promise_streak",
+    "get_promise_weekly_progress",
+    "get_promises",
+    "get_setting",
+    "get_settings",
+    "get_template",
+    "get_tool_help",
+    "get_upcoming_sessions",
+    "get_weekly_report",
+    "get_weekly_visualization",
+    "get_work_hour_suggestion",
+    "list_actions_filtered",
+    "list_templates",
+    "log_completed_activities",
+    "log_completed_activity",
+    "log_distraction",
+    "mark_session_done",
+    "mark_session_skipped",
+    "open_mini_app",
+    "schedule_session",
+    "schedule_sessions",
+    "set_language",
+    "set_timezone",
+    "subscribe_template",
+    "unfollow_user",
+    "update_plan_session_status",
+    "update_promise",
+    "update_promise_start_date",
+    "update_setting",
+    "upsert_profile_fact"
+  ],
+  "mcp_exposed": [
+    "add_checkin",
+    "add_promise",
+    "cancel_reminder",
+    "count_actions_on_date",
+    "count_actions_today",
+    "count_promises",
+    "create_recurring_reminder",
+    "create_reminder",
+    "delete_plan_session",
+    "delete_promise",
+    "follow_user",
+    "get_actions",
+    "get_actions_on_date",
+    "get_all_hours_total",
+    "get_community_stats",
+    "get_last_action_on_promise",
+    "get_my_followers",
+    "get_my_following",
+    "get_overload_status",
+    "get_plan_sessions",
+    "get_profile_status",
+    "get_promise",
+    "get_promise_hours_total",
+    "get_promise_report",
+    "get_promise_streak",
+    "get_promise_weekly_progress",
+    "get_promises",
+    "get_setting",
+    "get_settings",
+    "get_template",
+    "get_tool_help",
+    "get_upcoming_sessions",
+    "get_weekly_report",
+    "get_weekly_visualization",
+    "get_work_hour_suggestion",
+    "list_actions_filtered",
+    "list_templates",
+    "log_completed_activity",
+    "log_distraction",
+    "mark_session_done",
+    "mark_session_skipped",
+    "open_mini_app",
+    "schedule_session",
+    "set_language",
+    "set_timezone",
+    "subscribe_template",
+    "unfollow_user",
+    "update_plan_session_status",
+    "update_promise",
+    "update_promise_start_date",
+    "update_setting",
+    "upsert_profile_fact"
+  ]
+}

--- a/tm_bot/tests/adapter_tool_contract.snapshot.json
+++ b/tm_bot/tests/adapter_tool_contract.snapshot.json
@@ -1,10 +1,38 @@
 {
   "adapter_methods": {
+    "add_action": {
+      "alias_of": "log_completed_activity",
+      "doc": "Log time spent on a promise for an activity the user has ALREADY completed.",
+      "params": [
+        "promise_id",
+        "time_spent",
+        "action_datetime",
+        "notes"
+      ],
+      "required": [
+        "promise_id",
+        "time_spent"
+      ]
+    },
     "add_checkin": {
       "doc": "Record a yes/no check-in for a count-based promise. Use 'I did it today'-style messages.",
       "params": [
         "promise_id",
         "action_datetime"
+      ],
+      "required": [
+        "promise_id"
+      ]
+    },
+    "add_plan_session": {
+      "alias_of": "schedule_session",
+      "doc": "Schedule a FUTURE work session (time block) tied to an existing promise.",
+      "params": [
+        "promise_id",
+        "title",
+        "planned_start",
+        "planned_duration_min",
+        "notes"
       ],
       "required": [
         "promise_id"

--- a/tm_bot/tests/test_adapter_tool_contract.py
+++ b/tm_bot/tests/test_adapter_tool_contract.py
@@ -69,24 +69,39 @@ def _method_signature(node) -> Dict[str, List[str]]:
 
 
 def _adapter_methods() -> Dict[str, Dict]:
+    """Public callable surface of PlannerAPIAdapter, as the reflectors' ``dir()`` sees it.
+
+    Captures both ``def`` methods and class-level assignment aliases
+    (e.g. ``add_action = log_completed_activity``) — the latter are callable
+    attributes that runtime reflection exposes, so they are part of the contract.
+    """
     tree = ast.parse(_ADAPTER_SRC.read_text(encoding="utf-8"))
     cls = next(
         (n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "PlannerAPIAdapter"),
         None,
     )
     assert cls is not None, "PlannerAPIAdapter class not found"
+
     out: Dict[str, Dict] = {}
     for node in cls.body:
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and not node.name.startswith("_"):
+            sig = _method_signature(node)
+            out[node.name] = {
+                "params": sig["params"],
+                "required": sig["required"],
+                "doc": _first_doc_line(node),
+            }
+
+    # Resolve class-level aliases `name = other_name` to the target's signature/doc.
+    for node in cls.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Name):
             continue
-        if node.name.startswith("_"):
+        target_name = node.value.id
+        if target_name not in out:
             continue
-        sig = _method_signature(node)
-        out[node.name] = {
-            "params": sig["params"],
-            "required": sig["required"],
-            "doc": _first_doc_line(node),
-        }
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Name) and not tgt.id.startswith("_") and tgt.id not in out:
+                out[tgt.id] = {**out[target_name], "alias_of": target_name}
     return out
 
 

--- a/tm_bot/tests/test_adapter_tool_contract.py
+++ b/tm_bot/tests/test_adapter_tool_contract.py
@@ -1,0 +1,139 @@
+"""Contract snapshot for the reflected tool surface (see docs/ADAPTER_API_CONTRACT.md).
+
+``PlannerAPIAdapter``'s public methods are reflected into model-facing tools by both
+the LLM agent (``llms.llm_handler._build_tools``) and the MCP server
+(``tm_bot.mcp_server.tools.register_adapter_tools``). That makes method names,
+parameter names/defaults, first-line docstrings, and the exposed set a *published
+API*: changing any of them silently moves what Claude/ChatGPT see.
+
+This test snapshots that surface and fails on any drift, so the blast radius of an
+adapter edit shows up in review. The surface is derived by **statically parsing**
+``planner_api_adapter.py`` (no runtime deps / no DB), plus the exclusion sets from
+``llms.tool_exposure``.
+
+To accept an intentional change, regenerate the snapshot:
+
+    UPDATE_TOOL_CONTRACT=1 pytest tm_bot/tests/test_adapter_tool_contract.py
+
+and commit the updated ``adapter_tool_contract.snapshot.json`` in the same PR.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ADAPTER_SRC = _REPO_ROOT / "tm_bot" / "services" / "planner_api_adapter.py"
+_SNAPSHOT_PATH = Path(__file__).resolve().parent / "adapter_tool_contract.snapshot.json"
+
+# Stripped from model-facing signatures by llms/tool_wrappers._wrap_tool.
+_HIDDEN_PARAMS = {"self", "user_id"}
+
+
+def _first_doc_line(node: ast.AST) -> str:
+    doc = ast.get_docstring(node, clean=True) or ""
+    return doc.splitlines()[0].strip() if doc else ""
+
+
+def _method_signature(node) -> Dict[str, List[str]]:
+    """Model-facing params and required params for one adapter method (mirrors _wrap_tool)."""
+    a = node.args
+    positional = list(a.posonlyargs) + list(a.args)
+    # defaults align to the tail of `positional`
+    num_defaults = len(a.defaults)
+    defaulted = set(p.arg for p in positional[len(positional) - num_defaults:]) if num_defaults else set()
+
+    params: List[str] = []
+    required: List[str] = []
+    for p in positional:
+        if p.arg in _HIDDEN_PARAMS:
+            continue
+        params.append(p.arg)
+        if p.arg not in defaulted:
+            required.append(p.arg)
+    for p, d in zip(a.kwonlyargs, a.kw_defaults):
+        if p.arg in _HIDDEN_PARAMS:
+            continue
+        params.append(p.arg)
+        if d is None:  # kwonly with no default is required
+            required.append(p.arg)
+    return {"params": params, "required": required}
+
+
+def _adapter_methods() -> Dict[str, Dict]:
+    tree = ast.parse(_ADAPTER_SRC.read_text(encoding="utf-8"))
+    cls = next(
+        (n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "PlannerAPIAdapter"),
+        None,
+    )
+    assert cls is not None, "PlannerAPIAdapter class not found"
+    out: Dict[str, Dict] = {}
+    for node in cls.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name.startswith("_"):
+            continue
+        sig = _method_signature(node)
+        out[node.name] = {
+            "params": sig["params"],
+            "required": sig["required"],
+            "doc": _first_doc_line(node),
+        }
+    return out
+
+
+def _compute_snapshot() -> Dict:
+    from llms.tool_exposure import LLM_EXCLUDED_TOOLS, MCP_EXCLUDED_TOOLS
+
+    methods = _adapter_methods()
+    names = set(methods)
+    return {
+        "adapter_methods": methods,
+        "llm_exposed": sorted(names - set(LLM_EXCLUDED_TOOLS)),
+        "mcp_exposed": sorted(names - set(MCP_EXCLUDED_TOOLS)),
+    }
+
+
+def test_adapter_tool_contract_matches_snapshot():
+    current = _compute_snapshot()
+
+    if os.environ.get("UPDATE_TOOL_CONTRACT") == "1" or not _SNAPSHOT_PATH.exists():
+        _SNAPSHOT_PATH.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if os.environ.get("UPDATE_TOOL_CONTRACT") != "1":
+            pytest.skip(f"Bootstrapped tool-contract snapshot at {_SNAPSHOT_PATH.name}; commit it.")
+        return
+
+    saved = json.loads(_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    assert current == saved, (
+        "The reflected tool surface (PlannerAPIAdapter public methods / exposure) changed.\n"
+        "This moves what the LLM agent AND the MCP server expose — see docs/ADAPTER_API_CONTRACT.md.\n"
+        "If intentional, regenerate with:\n"
+        "    UPDATE_TOOL_CONTRACT=1 pytest tm_bot/tests/test_adapter_tool_contract.py\n"
+        "and commit the updated snapshot in the same PR."
+    )
+
+
+def test_no_excluded_tool_is_advertised_and_descriptions_exist():
+    """Defense-in-depth: exposed tools must have a description, and exclusions must be real methods."""
+    snap = _compute_snapshot()
+    methods = snap["adapter_methods"]
+
+    # Every exposed tool should carry a non-empty first-line docstring (its model description).
+    missing_doc = [n for n in snap["mcp_exposed"] if not methods.get(n, {}).get("doc")]
+    assert not missing_doc, f"MCP-exposed tools missing a docstring/description: {missing_doc}"
+
+    # Exclusion lists should not reference methods that no longer exist (stale denylist entries).
+    from llms.tool_exposure import LLM_EXCLUDED_TOOLS, MCP_EXCLUDED_TOOLS
+    known = set(methods)
+    stale_llm = sorted(set(LLM_EXCLUDED_TOOLS) - known)
+    stale_mcp = sorted(set(MCP_EXCLUDED_TOOLS) - known)
+    assert not stale_llm, f"LLM_EXCLUDED_TOOLS names no longer on the adapter: {stale_llm}"
+    assert not stale_mcp, f"MCP_EXCLUDED_TOOLS names no longer on the adapter: {stale_mcp}"


### PR DESCRIPTION
## Why
`PlannerAPIAdapter` is reflected into **both** the in-app LLM agent tools and the MCP tools, so its method names, signatures, docstrings, and exposed set are a *published API*. A ChatGPT↔MCP transcript showed this leaking deprecated concepts to users (e.g. "0.37 h/week"). This treats the surface as the contract it already is.

## What
- **Single source of truth** — new `llms/tool_exposure.py`; `llm_handler` and `mcp_server/tools` import their exclusion sets from it instead of two hand-copied denylists that had drifted.
- **Fixed the drift it surfaced** — MCP was exposing the five `async_*` duplicates plus `resolve_datetime`/`search_promises` that the LLM deliberately hides. MCP now excludes them (ChatGPT `search`/`fetch` covers remote search). Only remaining LLM↔MCP divergence is the intentional batch write-variants.
- **Promise API (additive)** — promise dicts now carry `tracking` (`time`|`count`) and `status` (`active`|`expired`); `get_promises` gains a `status` filter + a model-facing docstring (no more "weekly hours" framing). `hours_per_week` kept for back-compat (bot handlers read it).
- **Contract snapshot test** (`tm_bot/tests/test_adapter_tool_contract.py` + committed golden) — statically reflects the surface (74 methods incl. aliases → LLM 56 / MCP 52) and fails on drift. It already caught a real gap (class-level aliases).
- **Docs** — `docs/ADAPTER_API_CONTRACT.md`.

## Deferred (need consumer sign-off — higher breakage risk)
- Structured `get_weekly_report` breakdown (changes a return shape REST + LLM consume).
- Removing `hours_per_week` from the model-facing payload (bot handlers read it).
- Server-side promise-name cleaning (risks text-based lookups).

## CI note
The `pytest` job is red due to **14 pre-existing collection errors** (`tests.test_config` / `tests.conversation_eval` import failures) that are **identical on master** — not introduced here. They abort collection before any test runs, so the new contract test was verified locally instead (both assertions pass). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)