### PR TITLE
Structured get_weekly_breakdown for the model surface (#2) + clean promise names

### DIFF
--- a/tm_bot/llms/tool_exposure.py
+++ b/tm_bot/llms/tool_exposure.py
@@ -58,11 +58,18 @@ LLM_EXCLUDED_TOOLS: Set[str] = {
 # deliberately by *also* hiding the batch/plural write variants (keeping the
 # singular forms schedule_session / log_completed_activity / create_reminder)
 # and clear_profile_pending_question (bot-flow only).
+#
+# It also hides the two weekly views that only make sense in the Telegram bot:
+# get_weekly_report emits a target-percentage prose report (misleading for
+# count-based habits) and get_weekly_visualization returns an image marker the
+# bot renders. Remote clients get the structured get_weekly_breakdown instead.
 MCP_EXCLUDED_TOOLS: Set[str] = LLM_EXCLUDED_TOOLS | {
     "clear_profile_pending_question",
     "schedule_sessions",
     "log_completed_activities",
     "create_reminders",
+    "get_weekly_report",
+    "get_weekly_visualization",
 }
 
 

--- a/tm_bot/services/planner_api_adapter.py
+++ b/tm_bot/services/planner_api_adapter.py
@@ -782,6 +782,12 @@ class PlannerAPIAdapter:
         summary = self.reports_service.get_weekly_summary(user_id, reference_time)
         return self.reports_service.format_weekly_report(summary)
 
+    def get_weekly_breakdown(self, user_id, reference_time: Optional[datetime] = None):
+        """Structured weekly activity per active promise: check-ins for habits and hours for time goals (not a target percentage). Prefer this over get_weekly_report for analysis."""
+        if not reference_time:
+            reference_time = datetime.now()
+        return self.reports_service.get_weekly_breakdown(user_id, reference_time)
+
     def get_weekly_visualization(self, user_id, reference_time: Optional[datetime] = None) -> str:
         """Generate weekly visualization image for a user."""
         if not reference_time:
@@ -1311,7 +1317,10 @@ class PlannerAPIAdapter:
         is_expired = bool(promise.end_date and promise.end_date < date.today())
         return {
             'id': promise.id,
-            'text': promise.text,
+            # Display name: strip the legacy underscore encoding so every consumer
+            # (LLM/MCP/handlers) sees clean text, matching search/fetch and reports.
+            # Operations use 'id', not this text, so cleaning it is safe.
+            'text': promise.text.replace('_', ' '),
             'tracking': 'count' if promise.is_check_based() else 'time',
             'status': 'expired' if is_expired else 'active',
             'hours_per_week': promise.hours_per_week,

--- a/tm_bot/services/reports.py
+++ b/tm_bot/services/reports.py
@@ -80,8 +80,71 @@ class ReportsService:
                     report_data[promise.id] = all_promise_data[promise.id]
             elif self._promise_started_by(ref_time, promise.start_date):
                 report_data[promise.id] = all_promise_data[promise.id]
-        
+
         return report_data
+
+    def get_weekly_breakdown(self, user_id: int, ref_time: datetime) -> Dict[str, Any]:
+        """Structured weekly activity per active promise: check-ins and hours.
+
+        Unlike get_weekly_summary, this counts check-ins for count-based habits
+        (which have no hours target) and never scores anything as a percentage of
+        a weekly-hours quota. Expired promises (past their end date) are omitted.
+        """
+        if ref_time.tzinfo is not None:
+            ref_time = ref_time.replace(tzinfo=None)
+        week_start, week_end = get_week_range(ref_time)
+        today = date.today()
+
+        promises = self.promises_repo.list_promises(user_id)
+        actions = self.actions_repo.list_actions(user_id, since=week_start)
+
+        canonical_by_norm: Dict[str, str] = {}
+        agg: Dict[str, Dict[str, float]] = {}
+        for p in promises:
+            canonical_by_norm.setdefault(normalize_promise_id(p.id), p.id)
+            agg[p.id] = {"hours": 0.0, "checkins": 0}
+
+        for action in actions:
+            action_at = action.at.replace(tzinfo=None) if action.at.tzinfo else action.at
+            if not (week_start <= action_at <= week_end):
+                continue
+            canonical = canonical_by_norm.get(normalize_promise_id(action.promise_id))
+            if not canonical or canonical not in agg:
+                continue
+            # Count only real activity (a logged duration or an explicit check-in),
+            # not skip/delete bookkeeping actions.
+            if action.time_spent > 0 or action.action in ('checkin', 'club_checkin'):
+                agg[canonical]["hours"] += action.time_spent
+                agg[canonical]["checkins"] += 1
+
+        items: List[Dict[str, Any]] = []
+        total_hours = 0.0
+        total_checkins = 0
+        for p in promises:
+            if p.end_date and p.end_date < today:
+                continue  # skip expired — a weekly report is about live commitments
+            a = agg[p.id]
+            hours = round(a["hours"], 2)
+            items.append({
+                "id": p.id,
+                "name": p.text.replace('_', ' '),
+                "tracking": "count" if p.is_check_based() else "time",
+                "checkins": a["checkins"],
+                "hours": hours,
+            })
+            total_hours += hours
+            total_checkins += a["checkins"]
+
+        return {
+            "week_start": week_start.date().isoformat() if hasattr(week_start, 'date') else str(week_start),
+            "week_end": week_end.date().isoformat() if hasattr(week_end, 'date') else str(week_end),
+            "promises": items,
+            "totals": {
+                "active_promises": len(items),
+                "total_checkins": total_checkins,
+                "total_hours": round(total_hours, 2),
+            },
+        }
 
     def get_weekly_summary_with_sessions(self, user_id: int, ref_time: datetime) -> Dict[str, Any]:
         """Get weekly summary data with per-day session breakdown for visualization."""

--- a/tm_bot/tests/adapter_tool_contract.snapshot.json
+++ b/tm_bot/tests/adapter_tool_contract.snapshot.json
@@ -359,6 +359,13 @@
       ],
       "required": []
     },
+    "get_weekly_breakdown": {
+      "doc": "Structured weekly activity per active promise: check-ins for habits and hours for time goals (not a target percentage). Prefer this over get_weekly_report for analysis.",
+      "params": [
+        "reference_time"
+      ],
+      "required": []
+    },
     "get_weekly_report": {
       "doc": "Get the user's weekly progress report (hours logged vs promised per goal).",
       "params": [
@@ -678,6 +685,7 @@
     "get_template",
     "get_tool_help",
     "get_upcoming_sessions",
+    "get_weekly_breakdown",
     "get_weekly_report",
     "get_weekly_visualization",
     "get_work_hour_suggestion",
@@ -734,8 +742,7 @@
     "get_template",
     "get_tool_help",
     "get_upcoming_sessions",
-    "get_weekly_report",
-    "get_weekly_visualization",
+    "get_weekly_breakdown",
     "get_work_hour_suggestion",
     "list_actions_filtered",
     "list_templates",

--- a/tm_bot/tests/test_weekly_breakdown.py
+++ b/tm_bot/tests/test_weekly_breakdown.py
@@ -1,0 +1,67 @@
+"""Unit tests for ReportsService.get_weekly_breakdown (the structured weekly view).
+
+Validates the behaviour that the prose get_weekly_report could not express:
+count-based habits get check-ins counted, time goals get hours summed, expired
+promises are omitted, and nothing is scored against a weekly-hours target.
+"""
+
+from datetime import datetime, timedelta, date
+
+import pytest
+
+from models.models import Promise, Action
+from services.reports import ReportsService
+
+pytestmark = pytest.mark.unit
+
+
+class _Repo:
+    def __init__(self, items):
+        self._items = items
+
+    def list_promises(self, user_id):
+        return self._items
+
+    def list_actions(self, user_id, since=None):
+        return self._items
+
+
+def _svc(promises, actions):
+    return ReportsService(_Repo(promises), _Repo(actions))
+
+
+def test_weekly_breakdown_counts_checkins_and_hours_and_drops_expired():
+    now = datetime(2026, 6, 24, 12, 0)  # a Wednesday
+    future = date(2026, 12, 31)
+    past = date(2026, 1, 15)
+
+    promises = [
+        Promise(user_id="1", id="P01", text="Deep_work_(Stage11)", hours_per_week=20.0, end_date=future),
+        Promise(user_id="1", id="C01", text="Play Cheenva", hours_per_week=0.0, end_date=None),
+        Promise(user_id="1", id="P09", text="Play_piano", hours_per_week=0.67, end_date=past),  # expired
+    ]
+    actions = [
+        Action(user_id="1", promise_id="P01", action="log_time", time_spent=4.0, at=now),
+        Action(user_id="1", promise_id="P01", action="log_time", time_spent=2.0, at=now),
+        Action(user_id="1", promise_id="C01", action="checkin", time_spent=0.0, at=now),
+        Action(user_id="1", promise_id="C01", action="checkin", time_spent=0.0, at=now),
+        Action(user_id="1", promise_id="C01", action="checkin", time_spent=0.0, at=now),
+        Action(user_id="1", promise_id="C01", action="skip", time_spent=0.0, at=now),  # not counted
+        Action(user_id="1", promise_id="P09", action="log_time", time_spent=1.0, at=now),  # expired -> excluded
+    ]
+
+    out = _svc(promises, actions).get_weekly_breakdown(1, now)
+    by_id = {p["id"]: p for p in out["promises"]}
+
+    assert set(by_id) == {"P01", "C01"}  # expired P09 dropped
+    assert by_id["P01"] == {"id": "P01", "name": "Deep work (Stage11)", "tracking": "time", "checkins": 2, "hours": 6.0}
+    assert by_id["C01"] == {"id": "C01", "name": "Play Cheenva", "tracking": "count", "checkins": 3, "hours": 0.0}
+    assert out["totals"] == {"active_promises": 2, "total_checkins": 5, "total_hours": 6.0}
+
+
+def test_weekly_breakdown_empty_when_no_activity():
+    now = datetime(2026, 6, 24, 12, 0)
+    promises = [Promise(user_id="1", id="C01", text="Meditate", hours_per_week=0.0, end_date=None)]
+    out = _svc(promises, []).get_weekly_breakdown(1, now)
+    assert out["promises"] == [{"id": "C01", "name": "Meditate", "tracking": "count", "checkins": 0, "hours": 0.0}]
+    assert out["totals"] == {"active_promises": 1, "total_checkins": 0, "total_hours": 0.0}


### PR DESCRIPTION
## Why
Live smoke-testing the MCP showed `get_weekly_report` renders **every** promise as a `🔴 0%` bar against a weekly-hours target — including count-based habits that can never have hours, plus expired promises. It reads as "you've failed everything." Good enough for the Telegram bot, bad for Claude/ChatGPT.

## What
- **`ReportsService.get_weekly_breakdown` + adapter method** — per *active* promise: `{id, name, tracking, checkins, hours}` + totals. Check-ins counted for habits, hours summed for time goals, **no target percentage**, expired promises omitted, names cleaned.
- **MCP surface**: hide `get_weekly_report` (misleading prose) and `get_weekly_visualization` (image marker, useless remotely); expose `get_weekly_breakdown`. The **LLM/bot keep their existing tools** and also gain the breakdown — no behavior change to Telegram.
- **`get_promises`** now returns clean display names (strips legacy `_`), matching `search`/`fetch`/reports. Operations use `id`, not `text`, so this is display-only.
- Unit tests for the aggregation; contract snapshot regenerated (75 methods, llm 57 / mcp 51).

## Risk
Additive: a new method + a display-text cleanup + an MCP exposure change. No REST/bot return shapes change. `zana-mcp` must be rebuilt+recreated to pick this up (it's outside CI, same as before).

## CI note
The `pytest` job is still red from the **pre-existing** `tests.test_config` collection errors (tracked separately) — they abort collection before any test runs, so the new tests were validated by logic review + a live read-only call against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)