### PR TITLE
fix(ux): scheduled sessions first + future-start promises visible in My Week

### DIFF
--- a/tm_bot/services/reports.py
+++ b/tm_bot/services/reports.py
@@ -32,11 +32,6 @@ class ReportsService:
         week_sunday = week_start.date() + timedelta(days=6)
         return week_sunday < date.today()
 
-    @staticmethod
-    def _promise_started_by(ref_time: datetime, start_date: Optional[date]) -> bool:
-        """True when the promise had started by the reference week."""
-        return not start_date or start_date <= ref_time.date()
-
     def get_weekly_summary(self, user_id: int, ref_time: datetime) -> Dict[str, Any]:
         """Get weekly summary data for a user."""
         if ref_time.tzinfo is not None:
@@ -78,7 +73,7 @@ class ReportsService:
             if is_past_week:
                 if promise.id in promises_with_activity:
                     report_data[promise.id] = all_promise_data[promise.id]
-            elif self._promise_started_by(ref_time, promise.start_date):
+            elif not (promise.end_date and promise.end_date < date.today()):
                 report_data[promise.id] = all_promise_data[promise.id]
 
         return report_data
@@ -269,7 +264,7 @@ class ReportsService:
             report_data = {
                 promise.id: all_promise_data[promise.id]
                 for promise in promises
-                if self._promise_started_by(ref_time, promise.start_date)
+                if not (promise.end_date and promise.end_date < date.today())
             }
 
         # Handle budget templates with distraction_events

--- a/webapp_frontend/src/components/sheets/PromiseDetailSheet.tsx
+++ b/webapp_frontend/src/components/sheets/PromiseDetailSheet.tsx
@@ -120,8 +120,8 @@ export function PromiseDetailSheet({
   // Session being edited (opens ScheduleSheet in edit mode) / added to calendar
   const [editSession, setEditSession] = useState<PlanSession | null>(null);
   const [calendarSession, setCalendarSession] = useState<PlanSession | null>(null);
-  // A few recent activity logs (what was actually done on this promise) shown above the
-  // upcoming sessions, so the sheet reads as a short timeline: recently done, then planned.
+  // A few recent activity logs (what was actually done on this promise) shown below the
+  // upcoming sessions, so the sheet reads forward-first: what's planned next, then recently done.
   const [recentLogs, setRecentLogs] = useState<RecentLog[]>([]);
 
   const reloadSessions = useCallback(() => {
@@ -144,7 +144,15 @@ export function PromiseDetailSheet({
     return () => { cancelled = true; };
   }, [open, promiseId]);
 
-  const upcomingSessions = planSessions.filter(s => s.status === 'planned');
+  // Planned sessions, ordered chronologically (soonest first). Sessions with no
+  // time set sink to the bottom rather than jumping to the top.
+  const upcomingSessions = planSessions
+    .filter(s => s.status === 'planned')
+    .sort((a, b) => {
+      const ta = a.planned_start ? new Date(a.planned_start).getTime() : Infinity;
+      const tb = b.planned_start ? new Date(b.planned_start).getTime() : Infinity;
+      return ta - tb;
+    });
 
   // Pre-fill values for LogActionModal from the session being marked done
   const doneSession = logDoneSessionId !== null
@@ -280,33 +288,8 @@ export function PromiseDetailSheet({
         </>
       ) : null}
 
-      {/* Recent logs — what was actually done on this promise (read-only) */}
-      {recentLogs.length > 0 && (
-        <>
-          <p className="ds-eyebrow" style={{ marginTop: 16 }}>Recent</p>
-          <div className="recent-log-list">
-            {recentLogs.map((log, index) => {
-              const note = (log.notes ?? '').trim();
-              const amount = log.time_spent > 0 ? log.time_str : '';
-              return (
-                <div key={`${log.datetime}-${index}`} className="recent-log-row">
-                  <span className="recent-log-icon" aria-hidden>
-                    <Check size={12} />
-                  </span>
-                  <span className="recent-log-title">
-                    {note || (amount ? `${amount} logged` : 'Logged')}
-                  </span>
-                  <span className="recent-log-time">
-                    {note && amount ? `${amount} · ` : ''}{formatLogDate(log.date)}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </>
-      )}
-
-      {/* Planned sessions */}
+      {/* Planned sessions — upcoming work comes first; what's already done is
+          shown below under "Recent". */}
       {!sessionsLoading && upcomingSessions.length > 0 && (
         <>
           <p className="ds-eyebrow" style={{ marginTop: 16 }}>
@@ -360,6 +343,32 @@ export function PromiseDetailSheet({
                 </div>
               </div>
             ))}
+          </div>
+        </>
+      )}
+
+      {/* Recent logs — what was actually done on this promise (read-only) */}
+      {recentLogs.length > 0 && (
+        <>
+          <p className="ds-eyebrow" style={{ marginTop: 16 }}>Recent</p>
+          <div className="recent-log-list">
+            {recentLogs.map((log, index) => {
+              const note = (log.notes ?? '').trim();
+              const amount = log.time_spent > 0 ? log.time_str : '';
+              return (
+                <div key={`${log.datetime}-${index}`} className="recent-log-row">
+                  <span className="recent-log-icon" aria-hidden>
+                    <Check size={12} />
+                  </span>
+                  <span className="recent-log-title">
+                    {note || (amount ? `${amount} logged` : 'Logged')}
+                  </span>
+                  <span className="recent-log-time">
+                    {note && amount ? `${amount} · ` : ''}{formatLogDate(log.date)}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary

- **Scheduled before Recent in promise detail** — the sheet now reads forward-first: what's planned next, then what was done recently. The old order (recent on top) was backwards.
- **Chronological sort guaranteed** — planned sessions are now explicitly sorted by `planned_start` (soonest first, no-time sessions sink to bottom). Previously we trusted API return order, which wasn't guaranteed.
- **Future-start promises visible in My Week** — removed the `start_date` gate from `get_weekly_summary_with_sessions` and `get_weekly_summary`. A promise should appear in My Week from the moment it's created; start date is about when tracking begins, not a visibility switch. Expiry (`end_date < today`) remains the only exclusion criterion.

## Motivation

Discovered while dogfooding: creating a trip promise with `start_date=2026-07-09` caused it to vanish from My Week entirely until the trip started. That's the opposite of useful — you need to see and plan it *now*.

## Test plan

- [ ] Promise detail sheet: open any promise with both scheduled sessions and recent logs — scheduled should appear first
- [ ] Sessions should appear in date order (earliest first)
- [ ] Create a promise with a future start date — should immediately appear in My Week
- [ ] Expired promise (end_date in the past) should still be excluded from My Week

🤖 Generated with [Claude Code](https://claude.com/claude-code)