### PR TITLE
feat(challenges): automate Atena daily quiz ingestion + cancel

### DIFF
--- a/scripts/push_atena_quiz.py
+++ b/scripts/push_atena_quiz.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Push (or dry-run validate) a generated MCQ deck into the challenges engine.
+
+Used by the `atena-daily-french-quiz` scheduled task. Reads a deck JSON payload
+(title, source_ref, items) from stdin or --file, validates it, and either just
+reports the result (--dry-run, default) or writes it via ChallengesRepository
+(--publish).
+
+Run inside the zana-prod/zana-staging container, where PYTHONPATH includes
+/app and /app/tm_bot (see Dockerfile):
+
+    docker exec -i zana-prod python3 scripts/push_atena_quiz.py --dry-run < deck.json
+    docker exec -i zana-prod python3 scripts/push_atena_quiz.py --publish < deck.json
+
+Expected input JSON shape:
+{
+  "title": "Day N — <theme>",
+  "source_ref": "<stable id for the source post/image, e.g. its CDN URL or t.me permalink>",
+  "items": [
+    {"front": "...", "back": "<correct answer, must equal one option>",
+     "options": ["...", "...", "...", "..."], "example": null},
+    ... exactly 10 items ...
+  ]
+}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_CHALLENGE_ID = "660762b526d849ffa4470a9e690fc2d3"  # "French with Atena 🇫🇷"
+EXPECTED_ITEM_COUNT = 10
+LETTERS = "abcd"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def validate(deck: dict) -> list[str]:
+    """Return a list of error strings; empty list means the deck is publishable."""
+    errors = []
+    title = deck.get("title")
+    if not title or not isinstance(title, str):
+        errors.append("missing/invalid 'title'")
+    if not deck.get("source_ref"):
+        errors.append("missing 'source_ref' (needed for dedup)")
+
+    items = deck.get("items")
+    if not isinstance(items, list):
+        errors.append("'items' must be a list")
+        return errors
+    if len(items) != EXPECTED_ITEM_COUNT:
+        errors.append(f"expected {EXPECTED_ITEM_COUNT} items, got {len(items)}")
+
+    for i, item in enumerate(items, start=1):
+        front, back, options = item.get("front"), item.get("back"), item.get("options")
+        if not front:
+            errors.append(f"item {i}: missing 'front'")
+        if not back:
+            errors.append(f"item {i}: missing 'back'")
+        if not isinstance(options, list) or len(options) != 4:
+            errors.append(f"item {i}: 'options' must have exactly 4 entries")
+            continue
+        if len(set(options)) != 4:
+            errors.append(f"item {i}: duplicate options")
+        if back not in options:
+            errors.append(f"item {i}: 'back' ({back!r}) is not among 'options'")
+
+    return errors
+
+
+def answer_letter_distribution(items: list[dict]) -> Counter:
+    dist = Counter()
+    for item in items:
+        options = item.get("options") or []
+        back = item.get("back")
+        if back in options:
+            dist[LETTERS[options.index(back)]] += 1
+    return dist
+
+
+def compute_next_release_at(latest_release_at: str | None) -> str:
+    """One day after the queue tail, but never in the past (skips forward to the next
+    future day if the queue has been dry — e.g. after a multi-day gap)."""
+    now = datetime.now(timezone.utc)
+    if not latest_release_at:
+        candidate = now + timedelta(days=1)
+    else:
+        candidate = _parse_iso(latest_release_at) + timedelta(days=1)
+        while candidate <= now:
+            candidate += timedelta(days=1)
+    return candidate.isoformat().replace("+00:00", "Z")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", help="Path to deck JSON (default: stdin)")
+    parser.add_argument("--challenge-id", default=DEFAULT_CHALLENGE_ID)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True,
+                       help="Validate + report only, no DB write (default)")
+    mode.add_argument("--publish", action="store_true", help="Write the deck to the DB")
+    args = parser.parse_args()
+    publish = args.publish
+
+    raw = open(args.file, encoding="utf-8").read() if args.file else sys.stdin.read()
+    try:
+        deck = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"PUSH_STATUS=ERROR invalid JSON: {exc}")
+        return 2
+
+    errors = validate(deck)
+
+    from repositories.challenges_repo import ChallengesRepository  # noqa: E402 (deferred import)
+    repo = ChallengesRepository()
+
+    existing_refs = set(repo.get_source_refs(args.challenge_id))
+    source_ref = deck.get("source_ref")
+    is_dup = source_ref in existing_refs
+    if is_dup:
+        errors.append(f"source_ref {source_ref!r} already used for this challenge")
+
+    latest_release_at = repo.get_latest_release_at(args.challenge_id)
+    next_release_at = compute_next_release_at(latest_release_at)
+
+    items = deck.get("items") or []
+    dist = answer_letter_distribution(items)
+
+    print(f"title: {deck.get('title')}")
+    print(f"source_ref: {source_ref}")
+    print(f"item_count: {len(items)}")
+    print(f"answer_letter_distribution: {dict(sorted(dist.items()))}")
+    print(f"latest_existing_release_at: {latest_release_at}")
+    print(f"computed_release_at: {next_release_at}")
+
+    if errors:
+        print("VALIDATION_ERRORS:")
+        for e in errors:
+            print(f"  - {e}")
+        print("PUSH_STATUS=REJECTED")
+        return 1
+
+    if not publish:
+        print("PUSH_STATUS=DRY_RUN_OK (no DB write — pass --publish to push)")
+        return 0
+
+    result = repo.add_deck(
+        args.challenge_id,
+        deck["title"],
+        items,
+        position=repo.get_deck_count(args.challenge_id),  # append after existing decks
+        release_at=next_release_at,
+        source_ref=source_ref,
+    )
+    print(f"deck_id: {result['deck_id']}")
+    print("PUSH_STATUS=PUBLISHED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tm_bot/db/alembic/versions/030_challenge_deck_source_ref.py
+++ b/tm_bot/db/alembic/versions/030_challenge_deck_source_ref.py
@@ -1,0 +1,27 @@
+"""Add challenge_decks.source_ref — provenance of the deck's source content
+
+Lets automated ingestion (e.g. the Atena daily-quiz pipeline) dedupe against
+lessons already turned into a deck, without re-scraping/re-parsing history.
+
+Revision ID: 030_challenge_deck_source_ref
+Revises: 029_club_external_url
+Create Date: 2026-07-03
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "030_challenge_deck_source_ref"
+down_revision: Union[str, None] = "029_club_external_url"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("challenge_decks", sa.Column("source_ref", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("challenge_decks", "source_ref")

--- a/tm_bot/repositories/challenges_repo.py
+++ b/tm_bot/repositories/challenges_repo.py
@@ -513,18 +513,19 @@ class ChallengesRepository:
         return self.get(cid, host_user_id)
 
     def add_deck(self, challenge_id: str, title: str, items: List[dict], position: int = 0,
-                 release_at: Optional[str] = None) -> dict:
+                 release_at: Optional[str] = None, source_ref: Optional[str] = None) -> dict:
         """Create a deck plus its items in one shot (admin ingestion path)."""
         deck_id = _new_id()
         ts = _now_iso()
         with get_db_session() as session:
             session.execute(
                 text("""
-                    INSERT INTO challenge_decks (deck_id, challenge_id, title, position, release_at, created_at_utc)
-                    VALUES (:deck, :cid, :title, :pos, :rel, :ts)
+                    INSERT INTO challenge_decks
+                        (deck_id, challenge_id, title, position, release_at, source_ref, created_at_utc)
+                    VALUES (:deck, :cid, :title, :pos, :rel, :src, :ts)
                 """),
                 {"deck": deck_id, "cid": challenge_id, "title": title,
-                 "pos": position, "rel": release_at, "ts": ts},
+                 "pos": position, "rel": release_at, "src": source_ref, "ts": ts},
             )
             for i, item in enumerate(items):
                 options = item.get("options")
@@ -547,6 +548,72 @@ class ChallengesRepository:
                     },
                 )
         return {"deck_id": deck_id, "item_count": len(items)}
+
+    def get_source_refs(self, challenge_id: str) -> List[str]:
+        """All non-null source_refs already used for this challenge (dedup lookup)."""
+        with get_db_session() as session:
+            rows = session.execute(
+                text("""
+                    SELECT source_ref FROM challenge_decks
+                    WHERE challenge_id = :cid AND source_ref IS NOT NULL
+                """),
+                {"cid": challenge_id},
+            ).fetchall()
+            return [r[0] for r in rows]
+
+    def get_deck_count(self, challenge_id: str) -> int:
+        """Total decks (any state) for this challenge — used to append new decks' position."""
+        with get_db_session() as session:
+            row = session.execute(
+                text("SELECT COUNT(*) FROM challenge_decks WHERE challenge_id = :cid"),
+                {"cid": challenge_id},
+            ).fetchone()
+            return int(row[0]) if row else 0
+
+    def get_latest_release_at(self, challenge_id: str) -> Optional[str]:
+        """The latest release_at among this challenge's decks (queue tail), or None if empty."""
+        with get_db_session() as session:
+            row = session.execute(
+                text("""
+                    SELECT release_at FROM challenge_decks
+                    WHERE challenge_id = :cid AND release_at IS NOT NULL
+                    ORDER BY release_at DESC LIMIT 1
+                """),
+                {"cid": challenge_id},
+            ).fetchone()
+            return row[0] if row else None
+
+    def delete_deck(self, deck_id: str) -> bool:
+        """Cancel a not-yet-live deck. Refuses if it's already released or has attempts.
+
+        Returns True if deleted, False if the deck doesn't exist or isn't cancellable.
+        """
+        now = _now_iso()
+        with get_db_session() as session:
+            deck = session.execute(
+                text("SELECT release_at FROM challenge_decks WHERE deck_id = :deck"),
+                {"deck": deck_id},
+            ).fetchone()
+            if not deck:
+                return False
+            release_at = deck[0]
+            if release_at is None or release_at <= now:
+                return False  # already live (or always-visible) — not cancellable
+
+            attempted = session.execute(
+                text("SELECT 1 FROM challenge_attempts WHERE deck_id = :deck LIMIT 1"),
+                {"deck": deck_id},
+            ).fetchone()
+            if attempted:
+                return False  # never delete a deck someone already played
+
+            session.execute(
+                text("DELETE FROM challenge_items WHERE deck_id = :deck"), {"deck": deck_id}
+            )
+            session.execute(
+                text("DELETE FROM challenge_decks WHERE deck_id = :deck"), {"deck": deck_id}
+            )
+            return True
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/tm_bot/webapp/routers/challenges.py
+++ b/tm_bot/webapp/routers/challenges.py
@@ -132,3 +132,20 @@ async def admin_add_deck(
     return _repo().add_deck(
         challenge_id, body.title, items, position=body.position, release_at=body.release_at
     )
+
+
+@router.delete("/admin/challenges/{challenge_id}/decks/{deck_id}")
+async def admin_delete_deck(
+    challenge_id: str,
+    deck_id: str,
+    admin_id: int = Depends(get_admin_user),
+):
+    """Cancel a scheduled deck. Only allowed while it hasn't gone live and no one has played it."""
+    if not _repo().get(challenge_id, admin_id):
+        raise HTTPException(status_code=404, detail="Challenge not found")
+    if not _repo().delete_deck(deck_id):
+        raise HTTPException(
+            status_code=400,
+            detail="Deck not found, already released, or already has attempts",
+        )
+    return {"status": "deleted", "deck_id": deck_id}


### PR DESCRIPTION
## Summary
- Adds `challenge_decks.source_ref` (migration 030) for dedup/provenance of auto-generated decks.
- `ChallengesRepository`: `add_deck` accepts `source_ref`; new `get_source_refs`, `get_latest_release_at`, `get_deck_count`, `delete_deck` (guarded — only cancels future, unplayed decks).
- New `DELETE /api/admin/challenges/{challenge_id}/decks/{deck_id}` admin endpoint to cancel a scheduled deck.
- New `scripts/push_atena_quiz.py`: validates a generated 10-question MCQ deck (shape, dedup, answer-letter spread) and pushes it via `ChallengesRepository`, computing the next `release_at` slot in the existing daily queue.
- Updates the `atena-daily-french-quiz` scheduled task to iteration 2: generate 10 questions, dedup against `source_ref`, and push through the new script (dry-run first, publish once approved).

## Test plan
- [ ] Apply migration 030 on staging then prod, verify `alembic current` shows head
- [ ] Run `push_atena_quiz.py --dry-run` against prod with a sample deck, confirm zero DB writes and a clean report
- [ ] Run one `--publish` pass, confirm one new deck + 10 items row, correct `release_at`
- [ ] Exercise the cancel path: create a throwaway future deck, delete it via the new endpoint; confirm deleting an already-played deck (e.g. one of the June 21-25 seed decks) is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)