### PR TITLE
feat(challenges): naturalization flashcard ingestion + card/play UI polish

### DIFF
--- a/scripts/push_naturalisation_quiz.py
+++ b/scripts/push_naturalisation_quiz.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Push (or dry-run validate) flashcard decks into the challenges engine.
+
+Used for the "Entretien de naturalisation française" challenge (flashcard
+activity_type, self-paced — unlike the Atena MCQ challenge's daily drip).
+Reads a JSON array of decks (title, source_ref, items) from stdin or --file,
+validates each, and either just reports the result (--dry-run, default) or
+writes them via ChallengesRepository (--publish). All decks are released
+immediately (release_at = now), a few seconds apart to keep a stable order.
+
+Run inside the zana-prod/zana-staging container, where PYTHONPATH includes
+/app and /app/tm_bot (see Dockerfile):
+
+    docker exec -i zana-prod python3 scripts/push_naturalisation_quiz.py \
+        --challenge-id <id> --dry-run < decks.json
+    docker exec -i zana-prod python3 scripts/push_naturalisation_quiz.py \
+        --challenge-id <id> --publish < decks.json
+
+Expected input JSON shape (a list of decks):
+[
+  {
+    "title": "<theme>",
+    "source_ref": "<stable id for the source content, e.g. youtube:<id>#axe=1>",
+    "items": [
+      {"front": "...", "back": "..."},
+      ...
+    ]
+  },
+  ...
+]
+
+Unlike push_atena_quiz.py, items here are flashcards: no 'options', no fixed
+item count per deck, and 'back' is the answer shown after reveal rather than
+a value that must appear in a 4-choice list.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def validate(decks: list) -> list[str]:
+    """Return a list of error strings; empty list means the decks are publishable."""
+    errors = []
+    if not isinstance(decks, list) or not decks:
+        return ["input must be a non-empty JSON array of decks"]
+
+    seen_source_refs = set()
+    for d, deck in enumerate(decks, start=1):
+        title = deck.get("title")
+        if not title or not isinstance(title, str):
+            errors.append(f"deck {d}: missing/invalid 'title'")
+
+        source_ref = deck.get("source_ref")
+        if not source_ref:
+            errors.append(f"deck {d}: missing 'source_ref' (needed for dedup)")
+        elif source_ref in seen_source_refs:
+            errors.append(f"deck {d}: duplicate source_ref {source_ref!r} within this input")
+        else:
+            seen_source_refs.add(source_ref)
+
+        items = deck.get("items")
+        if not isinstance(items, list) or not items:
+            errors.append(f"deck {d} ({title!r}): 'items' must be a non-empty list")
+            continue
+
+        for i, item in enumerate(items, start=1):
+            front, back = item.get("front"), item.get("back")
+            if not front or not isinstance(front, str):
+                errors.append(f"deck {d} item {i}: missing/invalid 'front'")
+            if not back or not isinstance(back, str):
+                errors.append(f"deck {d} item {i}: missing/invalid 'back'")
+            if item.get("options"):
+                errors.append(f"deck {d} item {i}: flashcard items must not have 'options'")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", help="Path to decks JSON (default: stdin)")
+    parser.add_argument("--challenge-id", required=True)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True,
+                       help="Validate + report only, no DB write (default)")
+    mode.add_argument("--publish", action="store_true", help="Write the decks to the DB")
+    args = parser.parse_args()
+    publish = args.publish
+
+    raw = open(args.file, encoding="utf-8").read() if args.file else sys.stdin.read()
+    try:
+        decks = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"PUSH_STATUS=ERROR invalid JSON: {exc}")
+        return 2
+
+    errors = validate(decks)
+
+    from repositories.challenges_repo import ChallengesRepository  # noqa: E402 (deferred import)
+    repo = ChallengesRepository()
+
+    existing_refs = set(repo.get_source_refs(args.challenge_id))
+    for d, deck in enumerate(decks, start=1):
+        source_ref = deck.get("source_ref")
+        if source_ref in existing_refs:
+            errors.append(f"deck {d}: source_ref {source_ref!r} already used for this challenge")
+
+    total_items = sum(len(deck.get("items") or []) for deck in decks)
+    print(f"deck_count: {len(decks)}")
+    print(f"total_item_count: {total_items}")
+    for d, deck in enumerate(decks, start=1):
+        print(f"  deck {d}: {deck.get('title')!r} — {len(deck.get('items') or [])} items "
+              f"(source_ref={deck.get('source_ref')})")
+
+    if errors:
+        print("VALIDATION_ERRORS:")
+        for e in errors:
+            print(f"  - {e}")
+        print("PUSH_STATUS=REJECTED")
+        return 1
+
+    if not publish:
+        print("PUSH_STATUS=DRY_RUN_OK (no DB write — pass --publish to push)")
+        return 0
+
+    base_position = repo.get_deck_count(args.challenge_id)
+    now = datetime.now(timezone.utc)
+    for d, deck in enumerate(decks):
+        # Stagger release_at by a second per deck so ordering is stable and
+        # deterministic, while every deck is playable immediately (self-paced).
+        release_at = (now + timedelta(seconds=d)).isoformat().replace("+00:00", "Z")
+        result = repo.add_deck(
+            args.challenge_id,
+            deck["title"],
+            deck["items"],
+            position=base_position + d,
+            release_at=release_at,
+            source_ref=deck.get("source_ref"),
+        )
+        print(f"deck_id: {result['deck_id']} ({deck['title']!r})")
+
+    print("PUSH_STATUS=PUBLISHED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/webapp_frontend/src/pages/ChallengeDetailPage.tsx
+++ b/webapp_frontend/src/pages/ChallengeDetailPage.tsx
@@ -11,7 +11,7 @@ const textPrimary = 'var(--color-text-primary, #E6EAF2)';
 const textSecondary = 'var(--color-text-secondary, #8A94A6)';
 const accent = '#5DCAA5';
 
-const ACTIVITY_LABEL: Record<string, string> = { flashcard: 'Flashcards', multiple_choice: 'Quiz' };
+const ACTIVITY_LABEL: Record<string, string> = { flashcard: 'Quiz', multiple_choice: 'Quiz' };
 
 export function ChallengeDetailPage() {
   const navigate = useNavigate();

--- a/webapp_frontend/src/pages/ChallengePlayPage.tsx
+++ b/webapp_frontend/src/pages/ChallengePlayPage.tsx
@@ -290,7 +290,7 @@ export function ChallengePlayPage() {
         ) : null}
         {isFlashcard && revealed ? (
           <div style={{ marginTop: 16, paddingTop: 16, borderTop: `1px solid ${border}`, width: '100%' }}>
-            <div style={{ fontSize: 22, fontWeight: 700, color: accent }}>{item.back}</div>
+            <div style={{ fontSize: 16, fontWeight: 500, lineHeight: 1.5, color: accent }}>{item.back}</div>
           </div>
         ) : null}
       </div>

--- a/webapp_frontend/src/pages/ChallengesPage.tsx
+++ b/webapp_frontend/src/pages/ChallengesPage.tsx
@@ -6,7 +6,7 @@ import { useTelegramWebApp } from '../hooks/useTelegramWebApp';
 import type { ChallengeSummary } from '../types';
 
 const ACTIVITY_LABEL: Record<string, string> = {
-  flashcard: 'Flashcards',
+  flashcard: 'Quiz',
   multiple_choice: 'Quiz',
 };
 
@@ -116,7 +116,7 @@ export function ChallengesPage() {
                     letterSpacing: 0.3,
                     textTransform: 'uppercase',
                     color: '#0B0F1A',
-                    background: c.activity_type === 'multiple_choice' ? '#7FB2F0' : '#5DCAA5',
+                    background: '#7FB2F0',
                     borderRadius: 999,
                     padding: '4px 10px',
                     display: 'inline-flex',

--- a/webapp_frontend/src/pages/TemplatesPage.tsx
+++ b/webapp_frontend/src/pages/TemplatesPage.tsx
@@ -11,7 +11,7 @@ import type { AvatarStackUser } from '../components/ui/AvatarStack';
 type TemplateUser = AvatarStackUser;
 
 const CHALLENGE_ACTIVITY_LABEL: Record<string, string> = {
-  flashcard: 'Flashcards',
+  flashcard: 'Quiz',
   multiple_choice: 'Quiz',
 };
 
@@ -154,7 +154,7 @@ export function TemplatesPage() {
                       letterSpacing: 0.3,
                       textTransform: 'uppercase',
                       color: '#0B0F1A',
-                      background: c.activity_type === 'multiple_choice' ? '#7FB2F0' : '#5DCAA5',
+                      background: '#7FB2F0',
                       borderRadius: 999,
                       padding: '4px 10px',
                       display: 'inline-flex',


### PR DESCRIPTION
## Summary

Follow-up to the newly-published **French Naturalization Prep 🇫🇷** flashcard challenge (13 decks / 160 items, already live in prod DB). This PR lands the reusable ingestion tooling and the frontend polish so the flashcard challenge sits consistently next to the MCQ "French with Atena" one.

## Changes

- **`scripts/push_naturalisation_quiz.py`** — flashcard counterpart to `push_atena_quiz.py`: validates front/back (no MCQ options), accepts a multi-deck JSON array, and publishes all decks with an immediate `release_at` for self-paced bulk study (vs Atena's one-deck-per-day drip).
- **Card labels** — flashcard challenges now show a **"Quiz"** badge (not "Flashcards"), with the badge color unified across activity types, in the Explore marketplace, challenges list, and detail pages.
- **Play view** — flashcard answer text shrunk from `22px/700` to `16px/500` + `line-height 1.5`, so long paragraph answers read as body text instead of an oversized block.

## Notes

- The challenge title/summary and its backing template/club names were already updated directly in the prod DB (not code) and are live.
- No backend/schema changes; the challenges engine already supported flashcards (`activity_type='flashcard'` is the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)